### PR TITLE
Management of Bluemix staging address

### DIFF
--- a/src/ibmiotf/__init__.py
+++ b/src/ibmiotf/__init__.py
@@ -37,11 +37,16 @@ class Message:
 		self.timestamp = timestamp
 	
 class AbstractClient:
-	def __init__(self, organization, clientId, username, password, logHandlers=None):
+	def __init__(self, organization, clientId, username, password, logHandlers=None, staging=None):
 		self.organization = organization
 		self.username = username
 		self.password = password
-		self.address = organization + ".messaging.internetofthings.ibmcloud.com"
+
+		# Modify address if staging
+		self.staging = staging
+		stagingAddress = "staging." if (staging != None and staging == '1') else ""
+		
+		self.address = organization + ".messaging." + stagingAddress + "internetofthings.ibmcloud.com"
 		self.port = 1883
 		self.keepAlive = 60
 		

--- a/src/ibmiotf/api.py
+++ b/src/ibmiotf/api.py
@@ -86,8 +86,10 @@ class ApiClient():
 		
 		# Get the orgId from the apikey
 		self.__options['org'] = self.__options['auth-key'][2:8]
-		
-		self.host = self.__options['org'] + ".internetofthings.ibmcloud.com"
+   		
+   		stagingAddress = ".staging" if (self.__options['staging'] != None and self.__options['staging'] == '1') else ""
+
+		self.host = self.__options['org'] + stagingAddress + ".internetofthings.ibmcloud.com"
 		self.credentials = (self.__options['auth-key'], self.__options['auth-token'])
 		
 		# To support development systems this can be overridden to False

--- a/src/ibmiotf/gateway.py
+++ b/src/ibmiotf/gateway.py
@@ -75,14 +75,18 @@ class Client(AbstractClient):
 			else:
 				raise UnsupportedAuthenticationMethod(options['authMethod'])
 		self._options['subscriptionList'] = {}
-		
+
+		# Include staging
+		self._options['staging'] = options['staging'] if 'staging' in options else None
+			
 		AbstractClient.__init__(
 			self, 
 			organization = options['org'],
 			clientId = "g:" + options['org'] + ":" + options['type'] + ":" + options['id'], 
 			username = "use-token-auth" if (options['auth-method'] == "token") else None,
 			password = options['auth-token'],
-			logHandlers = logHandlers
+			logHandlers = logHandlers,
+			staging = options['staging']
 		)
 
 
@@ -232,7 +236,7 @@ class Client(AbstractClient):
 
 #		Kept this as a template 
 #		orgUrl = 'http://quickstart.internetofthings.ibmcloud.com/api/v0002/device/types/arduino/devices/00aabbccde02/events/status'
-		templateUrl = '%s://%s.internetofthings.ibmcloud.com/api/v0002/device/types/%s/devices/%s/events/%s'
+		templateUrl = '%s://%s%s.internetofthings.ibmcloud.com/api/v0002/device/types/%s/devices/%s/events/%s'
 
 #		Extracting all the values needed for the ReST operation
 #		Checking each value for 'None' is not needed as the device itself would not have got created, if it had any 'None' values
@@ -248,8 +252,11 @@ class Client(AbstractClient):
 		else:
 			protocol = 'https'
 
+		# Modify URL is staging 
+   		stagingAddress = ".staging" if ('staging' in self._options and self._options['staging'] == '1') else ""
+
 #		String replacement from template to actual URL
-		intermediateUrl = templateUrl % (protocol, orgid, deviceType, deviceId, event)
+		intermediateUrl = templateUrl % (protocol, orgid, stagingAddress, deviceType, deviceId, event)
 
 		try:
 			msgFormat = "json"
@@ -740,6 +747,7 @@ def ParseConfigFile(configFilePath):
 				deviceId = parms.get(sectionHeader, "id", fallback=None)
 				authMethod = parms.get(sectionHeader, "auth-method", fallback=None)
 				authToken = parms.get(sectionHeader, "auth-token", fallback=None)
+				staging = parms.get(sectionHeader, "staging", fallback=None)
 			except AttributeError:
 				# Python 2.7 support
 				# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file
@@ -749,9 +757,10 @@ def ParseConfigFile(configFilePath):
 				deviceId = parms.get(sectionHeader, "id", None)
 				authMethod = parms.get(sectionHeader, "auth-method", None)
 				authToken = parms.get(sectionHeader, "auth-token", None)
+				staging = parms.get(sectionHeader, "staging", None)
 		
 	except IOError as e:
 		reason = "Error reading gateway configuration file '%s' (%s)" % (configFilePath,e[1])
 		raise ConfigurationException(reason)
 		
-	return {'org': organization, 'type': deviceType, 'id': deviceId, 'auth-method': authMethod, 'auth-token': authToken}
+	return {'org': organization, 'type': deviceType, 'id': deviceId, 'auth-method': authMethod, 'auth-token': authToken, 'staging': staging}

--- a/test/applicationTest.py
+++ b/test/applicationTest.py
@@ -62,7 +62,7 @@ class TestApplication:
                                               "auth-method": "token", "auth-token": self.authToken, "auth-key":self.authKey})
         assert_is_instance(client , ibmiotf.application.Client)
         
-        assert_equals(client.clientId , "A:"+self.org+":"+self.deviceId)
+        assert_equals(client.clientId , "a:"+self.org+":"+self.deviceId)
         
     @raises(Exception)
     def testMissingAuthToken1(self):


### PR DESCRIPTION
It is possible specify a new options "staging" in the configuration file (or as dict key). If the value of this option is 1 then correct staging addresses and URLs are generated and used for the application. 