### PR TITLE
add clean_session support and fix 2.7 config parser case

### DIFF
--- a/src/ibmiotf/__init__.py
+++ b/src/ibmiotf/__init__.py
@@ -37,6 +37,7 @@ class Message:
 		self.timestamp = timestamp
 	
 class AbstractClient:
+	def __init__(self, domain, organization, clientId, username, password, logHandlers=None, cleanSession="true"):
 		self.organization = organization
 		self.username = username
 		self.password = password

--- a/src/ibmiotf/__init__.py
+++ b/src/ibmiotf/__init__.py
@@ -37,7 +37,6 @@ class Message:
 		self.timestamp = timestamp
 	
 class AbstractClient:
-	def __init__(self, domain, organization, clientId, username, password, logHandlers=None):
 		self.organization = organization
 		self.username = username
 		self.password = password
@@ -84,7 +83,7 @@ class AbstractClient:
 			self.logger.addHandler(rfh)
 			self.logger.addHandler(ch)
 		
-		self.client = paho.Client(self.clientId, clean_session=True)
+		self.client = paho.Client(self.clientId, clean_session=False if cleanSession == "false" else True)
 		
 		try:
 			self.tlsVersion = ssl.PROTOCOL_TLSv1_2

--- a/src/ibmiotf/application.py
+++ b/src/ibmiotf/application.py
@@ -506,26 +506,19 @@ def ParseConfigFile(configFilePath):
 		with open(configFilePath) as f:
 			try:
 				parms.read_file(f)
-				
-				domain = parms.get(sectionHeader, "domain")
-				appId = parms.get(sectionHeader, "id")
-				appType = parms.get(sectionHeader, "type")
-				
-				authKey = parms.get(sectionHeader, "auth-key")
-				authToken = parms.get(sectionHeader, "auth-token")
-				cleanSession = parms.get(sectionHeader, "clean-session")
 			except AttributeError:
 				# Python 2.7 support
 				# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file
 				parms.readfp(f)
 
-				domain = parms.get(sectionHeader, "domain")
-				appId = parms.get(sectionHeader, "id")
-				appType = parms.get(sectionHeader, "type")
+		domain = parms.get(sectionHeader, "domain")
+		appId = parms.get(sectionHeader, "id")
+		appType = parms.get(sectionHeader, "type")
+		
+		authKey = parms.get(sectionHeader, "auth-key")
+		authToken = parms.get(sectionHeader, "auth-token")
+		cleanSession = parms.get(sectionHeader, "clean-session")
 				
-				authKey = parms.get(sectionHeader, "auth-key")
-				authToken = parms.get(sectionHeader, "auth-token")
-				cleanSession = parms.get(sectionHeader, "clean-session")
 	except IOError as e:
 		reason = "Error reading application configuration file '%s' (%s)" % (configFilePath,e[1])
 		raise ibmiotf.ConfigurationException(reason)

--- a/src/ibmiotf/application.py
+++ b/src/ibmiotf/application.py
@@ -492,7 +492,8 @@ class Client(ibmiotf.AbstractClient):
 Parse a standard application configuration file
 '''
 def ParseConfigFile(configFilePath):
-	parms = configparser.ConfigParser()
+	parms = configparser.ConfigParser({"domain": "internetofthings.ibmcloud.com",
+	                                   "type": "standalone"})
 	sectionHeader = "application"
 
 	try:
@@ -500,23 +501,23 @@ def ParseConfigFile(configFilePath):
 			try:
 				parms.read_file(f)
 				
-				domain = parms.get(sectionHeader, "domain", fallback="internetofthings.ibmcloud.com")
-				appId = parms.get(sectionHeader, "id", fallback=None)
-				appType = parms.get(sectionHeader, "type", fallback="standalone")
+				domain = parms.get(sectionHeader, "domain")
+				appId = parms.get(sectionHeader, "id")
+				appType = parms.get(sectionHeader, "type")
 				
-				authKey = parms.get(sectionHeader, "auth-key", fallback=None)
-				authToken = parms.get(sectionHeader, "auth-token", fallback=None)
+				authKey = parms.get(sectionHeader, "auth-key")
+				authToken = parms.get(sectionHeader, "auth-token")
 			except AttributeError:
 				# Python 2.7 support
 				# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file
 				parms.readfp(f)
 
-				domain = parms.get(sectionHeader, "domain", "internetofthings.ibmcloud.com")
-				appId = parms.get(sectionHeader, "id", None)
-				appType = parms.get(sectionHeader, "type", "standalone")
+				domain = parms.get(sectionHeader, "domain")
+				appId = parms.get(sectionHeader, "id")
+				appType = parms.get(sectionHeader, "type")
 				
-				authKey = parms.get(sectionHeader, "auth-key", None)
-				authToken = parms.get(sectionHeader, "auth-token", None)
+				authKey = parms.get(sectionHeader, "auth-key")
+				authToken = parms.get(sectionHeader, "auth-token")
 	except IOError as e:
 		reason = "Error reading application configuration file '%s' (%s)" % (configFilePath,e[1])
 		raise ibmiotf.ConfigurationException(reason)

--- a/src/ibmiotf/application.py
+++ b/src/ibmiotf/application.py
@@ -147,10 +147,14 @@ class Client(ibmiotf.AbstractClient):
 		username = None
 		password = None
 		
+		### DEFAULTS ###
 		if "domain" not in self._options:
 			# Default to the domain for the public cloud offering
 			self._options['domain'] = "internetofthings.ibmcloud.com"
-
+		if "clean-session" not in self._options:
+		    self._options['clean-session'] = "true"
+		
+		### REQUIRED ###
 		if 'auth-key' not in self._options or self._options['auth-key'] is None:
 			# Configure for Quickstart
 			self._options['org'] = "quickstart"
@@ -178,7 +182,8 @@ class Client(ibmiotf.AbstractClient):
 			clientId = clientIdPrefix + ":" + self._options['org'] + ":" + self._options['id'], 
 			username = username, 
 			password = password,
-			logHandlers = logHandlers
+			logHandlers = logHandlers,
+			cleanSession = self._options['clean-session']
 		)
 		
 		# Add handlers for events and status
@@ -493,7 +498,8 @@ Parse a standard application configuration file
 '''
 def ParseConfigFile(configFilePath):
 	parms = configparser.ConfigParser({"domain": "internetofthings.ibmcloud.com",
-	                                   "type": "standalone"})
+										"type": "standalone",
+										"clean-session": "true"})
 	sectionHeader = "application"
 
 	try:
@@ -507,6 +513,7 @@ def ParseConfigFile(configFilePath):
 				
 				authKey = parms.get(sectionHeader, "auth-key")
 				authToken = parms.get(sectionHeader, "auth-token")
+				cleanSession = parms.get(sectionHeader, "clean-session")
 			except AttributeError:
 				# Python 2.7 support
 				# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file
@@ -518,11 +525,12 @@ def ParseConfigFile(configFilePath):
 				
 				authKey = parms.get(sectionHeader, "auth-key")
 				authToken = parms.get(sectionHeader, "auth-token")
+				cleanSession = parms.get(sectionHeader, "clean-session")
 	except IOError as e:
 		reason = "Error reading application configuration file '%s' (%s)" % (configFilePath,e[1])
 		raise ibmiotf.ConfigurationException(reason)
 		
-	return {'domain': domain, 'id': appId, 'auth-key': authKey, 'auth-token': authToken, 'type': appType}
+	return {'domain': domain, 'id': appId, 'auth-key': authKey, 'auth-token': authToken, 'type': appType, 'clean-session': cleanSession}
 
 
 def ParseConfigFromBluemixVCAP():

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -809,27 +809,19 @@ def ParseConfigFile(configFilePath):
 		with open(configFilePath) as f:
 			try:
 				parms.read_file(f)
-				
-				domain = parms.get(sectionHeader, "domain")
-				organization = parms.get(sectionHeader, "org")
-				deviceType = parms.get(sectionHeader, "type")
-				deviceId = parms.get(sectionHeader, "id")
-				authMethod = parms.get(sectionHeader, "auth-method")
-				authToken = parms.get(sectionHeader, "auth-token")
-				cleanSession = parms.get(sectionHeader, "clean-session")
 			except AttributeError:
 				# Python 2.7 support
 				# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file
 				parms.readfp(f)
 				
-				domain = parms.get(sectionHeader, "domain")
-				organization = parms.get(sectionHeader, "org")
-				deviceType = parms.get(sectionHeader, "type")
-				deviceId = parms.get(sectionHeader, "id")
-				authMethod = parms.get(sectionHeader, "auth-method")
-				authToken = parms.get(sectionHeader, "auth-token")
-				cleanSession = parms.get(sectionHeader, "clean-session")
-		
+		domain = parms.get(sectionHeader, "domain")
+		organization = parms.get(sectionHeader, "org")
+		deviceType = parms.get(sectionHeader, "type")
+		deviceId = parms.get(sectionHeader, "id")
+		authMethod = parms.get(sectionHeader, "auth-method")
+		authToken = parms.get(sectionHeader, "auth-token")
+		cleanSession = parms.get(sectionHeader, "clean-session")
+				
 	except IOError as e:
 		reason = "Error reading device configuration file '%s' (%s)" % (configFilePath,e[1])
 		raise ConfigurationException(reason)

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -798,30 +798,30 @@ class ManagedClient(Client):
 
 
 def ParseConfigFile(configFilePath):
-	parms = configparser.ConfigParser()
+	parms = configparser.ConfigParser({"domain": "internetofthings.ibmcloud.com"})
 	sectionHeader = "device"
 	try:
 		with open(configFilePath) as f:
 			try:
 				parms.read_file(f)
 				
-				domain = parms.get(sectionHeader, "domain", fallback="internetofthings.ibmcloud.com")
-				organization = parms.get(sectionHeader, "org", fallback=None)
-				deviceType = parms.get(sectionHeader, "type", fallback=None)
-				deviceId = parms.get(sectionHeader, "id", fallback=None)
-				authMethod = parms.get(sectionHeader, "auth-method", fallback=None)
-				authToken = parms.get(sectionHeader, "auth-token", fallback=None)
+				domain = parms.get(sectionHeader, "domain")
+				organization = parms.get(sectionHeader, "org")
+				deviceType = parms.get(sectionHeader, "type")
+				deviceId = parms.get(sectionHeader, "id")
+				authMethod = parms.get(sectionHeader, "auth-method")
+				authToken = parms.get(sectionHeader, "auth-token")
 			except AttributeError:
 				# Python 2.7 support
 				# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file
 				parms.readfp(f)
 				
-				domain = parms.get(sectionHeader, "domain", "internetofthings.ibmcloud.com")
-				organization = parms.get(sectionHeader, "org", None)
-				deviceType = parms.get(sectionHeader, "type", None)
-				deviceId = parms.get(sectionHeader, "id", None)
-				authMethod = parms.get(sectionHeader, "auth-method", None)
-				authToken = parms.get(sectionHeader, "auth-token", None)
+				domain = parms.get(sectionHeader, "domain")
+				organization = parms.get(sectionHeader, "org")
+				deviceType = parms.get(sectionHeader, "type")
+				deviceId = parms.get(sectionHeader, "id")
+				authMethod = parms.get(sectionHeader, "auth-method")
+				authToken = parms.get(sectionHeader, "auth-token")
 		
 	except IOError as e:
 		reason = "Error reading device configuration file '%s' (%s)" % (configFilePath,e[1])

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -57,10 +57,14 @@ class Client(AbstractClient):
 	def __init__(self, options, logHandlers=None):
 		self._options = options
 
+		### DEFAULTS ###
 		if "domain" not in self._options:
 			# Default to the domain for the public cloud offering
 			self._options['domain'] = "internetofthings.ibmcloud.com"
+		if "clean-session" not in self._options:
+			self._options['clean-session'] = "true"
 			
+		### REQUIRED ###	
 		if self._options['org'] == None:
 			raise ConfigurationException("Missing required property: org")
 		if self._options['type'] == None: 
@@ -86,9 +90,9 @@ class Client(AbstractClient):
 			clientId = "d:" + self._options['org'] + ":" + self._options['type'] + ":" + self._options['id'], 
 			username = "use-token-auth" if (self._options['auth-method'] == "token") else None,
 			password = self._options['auth-token'],
-			logHandlers = logHandlers
+			logHandlers = logHandlers,
+			cleanSession = self._options['clean-session']
 		)
-
 
 		# Add handler for commands if not connected to QuickStart
 		if self._options['org'] != "quickstart":
@@ -798,7 +802,8 @@ class ManagedClient(Client):
 
 
 def ParseConfigFile(configFilePath):
-	parms = configparser.ConfigParser({"domain": "internetofthings.ibmcloud.com"})
+	parms = configparser.ConfigParser({"domain": "internetofthings.ibmcloud.com",
+	                                   "clean-session": "true"})
 	sectionHeader = "device"
 	try:
 		with open(configFilePath) as f:
@@ -811,6 +816,7 @@ def ParseConfigFile(configFilePath):
 				deviceId = parms.get(sectionHeader, "id")
 				authMethod = parms.get(sectionHeader, "auth-method")
 				authToken = parms.get(sectionHeader, "auth-token")
+				cleanSession = parms.get(sectionHeader, "clean-session")
 			except AttributeError:
 				# Python 2.7 support
 				# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file
@@ -822,9 +828,10 @@ def ParseConfigFile(configFilePath):
 				deviceId = parms.get(sectionHeader, "id")
 				authMethod = parms.get(sectionHeader, "auth-method")
 				authToken = parms.get(sectionHeader, "auth-token")
+				cleanSession = parms.get(sectionHeader, "clean-session")
 		
 	except IOError as e:
 		reason = "Error reading device configuration file '%s' (%s)" % (configFilePath,e[1])
 		raise ConfigurationException(reason)
 		
-	return {'domain': domain, 'org': organization, 'type': deviceType, 'id': deviceId, 'auth-method': authMethod, 'auth-token': authToken}
+	return {'domain': domain, 'org': organization, 'type': deviceType, 'id': deviceId, 'auth-method': authMethod, 'auth-token': authToken, 'clean-session': cleanSession}


### PR DESCRIPTION
Error is:

  File "c:\git\ibm-messaging\iot-python\src\ibmiotf\device.py", line 820, in ParseConfigFile
    domain = parms.get(sectionHeader, "domain", "internetofthings.ibmcloud.com")
  File "C:\Python27\lib\ConfigParser.py", line 618, in get
    raise NoOptionError(option, section)
ConfigParser.NoOptionError: No option 'domain' in section: 'device'

ie the default was not effective.

With Python 2.7, the arguments passed to configparser.get() incorrectly assume the third argument is the "fallback" equivalent, or default, but that is actually the raw argument.  Also, there is no argument that can be passed to set the default, the dict that can be passed in 2.7 actually has precedence over what is actually in the file or the defaults.

Solution is to pass the defaults in the constructor.  Tested it works as expected in both 2.7 and 3 cases.