### PR TITLE
Merge DME support for DeviceClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *.log
 *.cfg
+*.conf
 *.pyc
 *.project
 *.pydevproject
 *.zip
+*.json
 src/ibmiotf.egg-info/*
 MANIFEST
 README.txt

--- a/docs/python_cli_for_manageddevice.rst
+++ b/docs/python_cli_for_manageddevice.rst
@@ -446,39 +446,9 @@ A device specifies what types of actions it supports when it publishes a manage 
 allow a device to receive custom actions defined in a particular extension package, the device must specify that extension’s
 bundle identifier in the supports object when publishing a manage request.
 
-Here is the sample python code to publish a mange request to indicate to IoT Platform that device supports DME Actions:
+Here is the sample python code to publish a manage request to indicate to IoT Platform that device supports DME Actions:
 
 .. code:: python
-
-	#Setup logger instance
-	logger = logging.getLogger(“DME”)
-	logger.setLevel(logging.INFO)
-
-	#Initialize Client for API to carry out REST Calls
-	appConfFile="application.conf"
-	appOptions = ibmiotf.application.ParseConfigFile(appConfFile)
-	apiClient = ibmiotf.api.ApiClient(appOptions , logger)
-
-	#Initialize DME Package Information
-	dmeData = {"bundleId": "example-dme-actions-v1",
-                   "displayName": { "en_US": "example-dme Actions v1" },
-                   "version": "1.0",
-		   "actions": {
-			"installPlugin": {
-              			"actionDisplayName": { "en_US": "Install Plug-in" },
-                   		"parameters": [ 
-						{ 
-						"name": "pluginURI",
-                                     		"value": "http://example.dme.com",
-                                    		"required": "true" 
-						} 
-					       ] 
-					} 
-				} 
-		}
-
-	# Create DME Package on the platform using API REST Call
-	addResult = apiClient.createDeviceManagementExtensionPkg(dmeData)
 
 	# Initialize ManagedClient
 	deviceFile="device.conf"
@@ -490,53 +460,17 @@ Here is the sample python code to publish a mange request to indicate to IoT Pla
 
 	# Send Manage request with DME actions set to true along with the bundle id to platform
 	managedClient.connect()
-	managedClient.unmanage()
 	managedClient.manage(lifetime=0,supportDeviceMgmtExtActions=True,bundleId='example-dme-actions-v1')
 
 In return, IoT Platform sends back response with rc=200 to device. For additional information about device manage requests,
 refer to `Device Management Protocol <https://docs.internetofthings.ibmcloud.com/devices/device_mgmt/index.html>`__.
 
-Initiating Custom Device Management Actions
---------------------------------------------------
-Custom device management actions are initiated using the same REST API as the default device management actions. The
-following information must be provided when initiating a request:
-
-* The action <bundleId>/<actionId>
-
-* A list of devices to initiate the action against, with a maximum of 5000 devices
-
-* A list of parameters as defined in the custom action definition
-
-Here is the sample python code to initiate DM request:
-
-.. code:: python
-
-	mgmtRequest = {
-		"action": "example-dme-actions-v1/installPlugin",
-                "parameters": [
-				{ 
-				"name": "pluginURI",
-                                "value": "http://example.dme.com",
-				}
-				],
-                "devices": [
-				{ 
-				"typeId": deviceType, 
-				"deviceId": deviceId 
-				}
-			    ]
-			}
-        
-	initResult = apiClient.initiateDeviceManagementRequest(mgmtRequest)
-	reqId = initResult['reqId']
-	
 Handling Custom Device Management Actions
 -------------------------------------------------
-When a custom action is initiated against a device, an MQTT message will be published to the device. The message will
-contain any parameters that were specified as part of the request. When the device receives this message, it is expected to
-either execute the action or respond with an error code indicating that it cannot complete the action at this time.
-
-To indicate that the action was completed successfully, a device should publish a response with rc set to 200.
+When a custom action is initiated against a device to the IoT Platform, an MQTT message will be published to the device. The
+message will contain any parameters that were specified as part of the request. When the device receives this message, it is
+expected to either execute the action or respond with an error code indicating that it cannot complete the action at this
+time. To indicate that the action was completed successfully, a device should publish a response with rc set to 200.
 
 As the device receives the MQTT message from the IoT Platform, the user registered DME callback function is expected to be
 called and executed. The user defined DME callback function exactly receives 3 parameters from the device:
@@ -562,21 +496,6 @@ Below given is the sample python code for user defined DME callback function:
             print("Received data = %s" %data)
             return True
         
-Clearing of Custom Device Management Action
--------------------------------------------------------
-As we finish of the custom device management action flow, we can clear of the requests from the IoT Platform and disconnect
-the managed client instance as shown in the below given python code snippet:
-
-.. code:: python
-
-	# Remove the completed requests from the platform
-	apiClient.deleteDeviceManagementExtensionPkg('example-dme-actions-v1')
-	apiClient.deleteDeviceManagementRequest(reqId)
-
-	# Unmanaged and disconnect the client
-	managedClient.unmanage()
-	managedClient.disconnect() 
-
-The complete code can be found in the device management sample `<https://github.com/ibm-messaging/iot-python/tree/master/samples/managedDevice>`__.
+The complete code can be found in the device management samples `<https://github.com/ibm-messaging/iot-python/tree/master/samples/managedDevice/>`__.
 
 For complete details on Device Management Extension, refer to `Extending Device Management <https://docs.internetofthings.ibmcloud.com/devices/device_mgmt/custom_actions.html>`__.	

--- a/samples/managedDevice/dmeAction.py
+++ b/samples/managedDevice/dmeAction.py
@@ -36,10 +36,9 @@ options = ibmiotf.device.ParseConfigFile(deviceFile)
 deviceType = options['type']
 deviceId = options['id']
 
-# Create ManagedClient Instance, connect follwed by unmanage
+# Create ManagedClient Instance,connect 
 managedClient = ibmiotf.device.ManagedClient(options,logger)
 managedClient.connect()
-managedClient.unmanage()
 
 # Parse application config file
 options = ibmiotf.application.ParseConfigFile(appConfFile)

--- a/samples/managedDevice/dmeAction.py
+++ b/samples/managedDevice/dmeAction.py
@@ -1,0 +1,95 @@
+# *****************************************************************************
+# Copyright (c) 2016 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Lokesh K Haralakatta - Initial Contribution
+# *****************************************************************************
+
+# Import required modules
+import ibmiotf.device
+import ibmiotf.application
+import ibmiotf.api
+import logging
+
+# Declare and Define instanaces to None
+managedClient=None
+apiClient=None
+options=None
+
+# Define paths of valid config files
+deviceFile="../../test/device.conf"
+appConfFile="../../test/application.conf"
+
+# Setup logger instance, not set to avoid log messages on std out
+logger = logging.getLogger("dmeSample")
+logger.setLevel(logging.NOTSET)
+
+# Parse device config file
+options = ibmiotf.device.ParseConfigFile(deviceFile)
+
+# Get deviceType and deviceId values from parsed data
+deviceType = options['type']
+deviceId = options['id']
+
+# Create ManagedClient Instance, connect follwed by unmanage
+managedClient = ibmiotf.device.ManagedClient(options,logger)
+managedClient.connect()
+managedClient.unmanage()
+
+# Parse application config file
+options = ibmiotf.application.ParseConfigFile(appConfFile)
+
+# Create an apiClient Instance
+apiClient = ibmiotf.api.ApiClient(options,logger)
+
+# Define the DME Action Data in proper JSON format
+dmeData = {"bundleId": "example-dme-actions-v1",
+           "displayName": {"en_US": "example-dme Actions v1"},
+           "version": "1.0","actions": {"installPlugin": {
+           "actionDisplayName": { "en_US": "Install Plug-in"},
+           "parameters": [ { "name": "pluginURI",
+                             "value": "http://example.dme.com",
+                            "required": "true" } ] } } }
+
+# Create DME Package using API Method
+addResult = apiClient.createDeviceManagementExtensionPkg(dmeData)
+
+# Define callback to carry out requested DME Action
+def doDMEAction(topic,data,reqId):
+    print("In DME Action Callabck")
+    print("Received topic = "+topic)
+    print("Received reqId = "+reqId)
+    print("Received data = %s" %data)
+    return True
+
+# Register above define function as DME callback function
+managedClient.dmeActionCallback = doDMEAction;
+
+# Send Manage Request to IoT Platform with indicating support of DME Actions by the Device
+managedClient.manage(lifetime=0,supportDeviceMgmtExtActions=True,bundleId='example-dme-actions-v1')
+
+# Define details of DM request containing DME Action,devices and parameters
+mgmtRequest = {"action": "example-dme-actions-v1/installPlugin",
+               "parameters": [{ "name": "pluginURI",
+                                 "value": "http://example.dme.com",}],
+               "devices": [{ "typeId": deviceType, "deviceId": deviceId }]}
+
+# Send DM Request for DME Action of installPlugin using API Method
+initResult = apiClient.initiateDeviceManagementRequest(mgmtRequest)
+reqId = initResult['reqId']
+
+# Here you should be able to see the result from registerd DME callback function
+# Device Client sends response to IoT Platform with RC=200 indicating success of the DME Action
+
+# It's time of clear of DME and DM request from the IoT Platform
+apiClient.deleteDeviceManagementExtensionPkg('example-dme-actions-v1')
+apiClient.deleteDeviceManagementRequest(reqId)
+
+# Get out of Manage Mode and Disconnect the client
+managedClient.unmanage()
+managedClient.disconnect()

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -816,7 +816,7 @@ class ManagedClient(Client):
 		if self.dmeActionCallback :
 			if self.dmeActionCallback(pahoMessage.topic,data,reqId):
 				msg = "DME Action successfully completed from Callback"
-			   	threading.Thread(target= self.respondDeviceAction,args=(reqId,200,msg)).start()
+				threading.Thread(target= self.respondDeviceAction,args=(reqId,200,msg)).start()
 		   	else:
 				msg = "Unexpected device error"
 			   	threading.Thread(target= self.respondDeviceAction,args=(reqId,500,msg)).start()

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -4,10 +4,11 @@
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html 
+# http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
 #   David Parker  - Initial Contribution
+#   Lokesh Haralakatta - Added DME Support
 # *****************************************************************************
 
 import json
@@ -51,7 +52,7 @@ class Command:
 
 
 class Client(AbstractClient):
-	
+
 	COMMAND_TOPIC = "iot-2/cmd/+/fmt/+"
 
 	def __init__(self, options, logHandlers=None):
@@ -63,31 +64,31 @@ class Client(AbstractClient):
 			self._options['domain'] = "internetofthings.ibmcloud.com"
 		if "clean-session" not in self._options:
 			self._options['clean-session'] = "true"
-			
-		### REQUIRED ###	
+
+		### REQUIRED ###
 		if self._options['org'] == None:
 			raise ConfigurationException("Missing required property: org")
-		if self._options['type'] == None: 
+		if self._options['type'] == None:
 			raise ConfigurationException("Missing required property: type")
-		if self._options['id'] == None: 
+		if self._options['id'] == None:
 			raise ConfigurationException("Missing required property: id")
-		
+
 		if self._options['org'] != "quickstart":
-			if self._options['auth-method'] == None: 
+			if self._options['auth-method'] == None:
 				raise ConfigurationException("Missing required property: auth-method")
-				
+
 			if (self._options['auth-method'] == "token"):
-				if self._options['auth-token'] == None: 
+				if self._options['auth-token'] == None:
 					raise ConfigurationException("Missing required property for token based authentication: auth-token")
 			else:
 				raise UnsupportedAuthenticationMethod(options['authMethod'])
 
 
 		AbstractClient.__init__(
-			self, 
+			self,
 			domain = self._options['domain'],
 			organization = self._options['org'],
-			clientId = "d:" + self._options['org'] + ":" + self._options['type'] + ":" + self._options['id'], 
+			clientId = "d:" + self._options['org'] + ":" + self._options['type'] + ":" + self._options['id'],
 			username = "use-token-auth" if (self._options['auth-method'] == "token") else None,
 			password = self._options['auth-token'],
 			logHandlers = logHandlers,
@@ -99,18 +100,18 @@ class Client(AbstractClient):
 			self.client.message_callback_add("iot-2/cmd/+/fmt/+", self.__onCommand)
 
 		self.subscriptionsAcknowledged = threading.Event()
-		
+
 		# Initialize user supplied callback
 		self.commandCallback = None
 
 		self.client.on_connect = self.on_connect
-		
+
 		self.setMessageEncoderModule('json', jsonCodec)
 		self.setMessageEncoderModule('json-iotf', jsonIotfCodec)
 
-	
+
 	'''
-	This is called after the client has received a CONNACK message from the broker in response to calling connect(). 
+	This is called after the client has received a CONNACK message from the broker in response to calling connect().
 	The parameter rc is an integer giving the return code:
 	0: Success
 	1: Refused - unacceptable protocol version
@@ -129,9 +130,9 @@ class Client(AbstractClient):
 			self.logAndRaiseException(ConnectionException("Not authorized: s (%s, %s, %s)" % (self.clientId, self.username, self.password)))
 		else:
 			self.logAndRaiseException(ConnectionException("Connection failed: RC= %s" % (rc)))
-	
+
 	'''
-	Publish an event in IoTF.  
+	Publish an event in IoTF.
 	Parameters:
 		event - the name of this event
 		msgFormat - the format of the data for this event
@@ -150,15 +151,15 @@ class Client(AbstractClient):
 		else:
 			self.logger.debug("Sending event %s with data %s" % (event, json.dumps(data)))
 			topic = 'iot-2/evt/'+event+'/fmt/' + msgFormat
-			
+
 			if msgFormat in self._messageEncoderModules:
 				payload = self._messageEncoderModules[msgFormat].encode(data, datetime.now(pytz.timezone('UTC')))
-				
+
 				try:
 					# need to take lock to ensure on_publish is not called before we know the mid
 					if on_publish is not None:
 						self._messagesLock.acquire()
-					
+
 					result = self.client.publish(topic, payload=payload, qos=qos, retain=False)
 					if result[0] == paho.MQTT_ERR_SUCCESS:
 						if on_publish is not None:
@@ -187,7 +188,7 @@ class Client(AbstractClient):
 		orgid = self._options['org']
 		deviceType = self._options['type']
 		deviceId = self._options['id']
-		authMethod = self._options['auth-method'] 
+		authMethod = self._options['auth-method']
 		authToken = self._options['auth-token']
 		credentials = (authMethod, authToken)
 
@@ -204,7 +205,7 @@ class Client(AbstractClient):
 			response = requests.post(intermediateUrl, auth = credentials, data = payload, headers = {'content-type': 'application/json'})
 		except Exception as e:
 			self.logger.error("POST Failed")
-			self.logger.error(e)			
+			self.logger.error(e)
 			raise ConnectionException("Server not found")
 
 #		print ("Response status = ", response.status_code, "\tResponse ", response.headers)
@@ -217,7 +218,7 @@ class Client(AbstractClient):
 		if self._options['org'] == "quickstart":
 			self.logger.warning("QuickStart applications do not support commands")
 			return False
-		
+
 		if not self.connectEvent.wait():
 			self.logger.warning("Unable to subscribe to commands because device is not currently connected")
 			return False
@@ -227,7 +228,7 @@ class Client(AbstractClient):
 			return True
 
 	'''
-	Internal callback for device command messages, parses source device from topic string and 
+	Internal callback for device command messages, parses source device from topic string and
 	passes the information on to the registerd device command callback
 	'''
 	def __onCommand(self, client, userdata, pahoMessage):
@@ -253,11 +254,11 @@ class DeviceInfo(object):
 		self.fwVersion = None
 		self.hwVersion = None
 		self.descriptiveLocation = None
-	
+
 	def __str__(self):
 		return json.dumps(self.__dict__, sort_keys=True)
 
-	
+
 class DeviceFirmware(object):
 	def __init__(self,version = None,name = None,url = None,verifier = None,state = None,updateStatus = None,updatedDateTime = None):
 		self.version = version
@@ -267,11 +268,11 @@ class DeviceFirmware(object):
 		self.state = state
 		self.updateStatus = updateStatus
 		self.updatedDateTime = updatedDateTime
-		
+
 	def __str__(self):
 		return json.dumps(self.__dict__, sort_keys=True)
 
-	
+
 class ManagedClient(Client):
 
 	# Publish MQTT topics
@@ -284,7 +285,7 @@ class ManagedClient(Client):
 	RESPONSE_TOPIC = 'iotdevice-1/response'
 	ADD_LOG_TOPIC = 'iotdevice-1/add/diag/log'
 	CLEAR_LOG_TOPIC = 'iotdevice-1/clear/diag/log'
-	
+
 	# Subscribe MQTT topics
 	DM_RESPONSE_TOPIC = 'iotdm-1/response'
 	DM_OBSERVE_TOPIC = 'iotdm-1/observe'
@@ -294,13 +295,14 @@ class ManagedClient(Client):
 	DM_CANCEL_OBSERVE_TOPIC = 'iotdm-1/cancel'
 	DM_FIRMWARE_DOWNLOAD_TOPIC = 'iotdm-1/mgmt/initiate/firmware/download'
 	DM_FIRMWARE_UPDATE_TOPIC = 'iotdm-1/mgmt/initiate/firmware/update'
-	
-	#ResponceCode 
+	DME_ACTION_TOPIC = 'iotdm-1/mgmt/custom/#'
+
+	#ResponceCode
 	RESPONSECODE_FUNCTION_NOT_SUPPORTED = 501
 	RESPONSECODE_ACCEPTED = 202
 	RESPONSECODE_INTERNAL_ERROR = 500
 	RESPONSECODE_BAD_REQUEST = 400
-	
+
 	UPDATESTATE_IDLE = 0
 	UPDATESTATE_DOWNLOADING = 1
 	UPDATESTATE_DOWNLOADED = 2
@@ -311,19 +313,20 @@ class ManagedClient(Client):
 	UPDATESTATE_VERIFICATION_FAILED = 4
 	UPDATESTATE_UNSUPPORTED_IMAGE = 5
 	UPDATESTATE_INVALID_URI = 6
-	
-	
+
+
 	def __init__(self, options, logHandlers=None, deviceInfo=None):
 		if options['org'] == "quickstart":
 			raise Exception("Unable to create ManagedClient instance.  QuickStart devices do not support device management")
 
 		Client.__init__(self, options, logHandlers)
 		# TODO: Raise fatal exception if tries to create managed device client for QuickStart
-		
+
 		# Initialize user supplied callback
 		self.deviceActionCallback = None
 		self.firmwereActionCallback  = None
-	
+		self.dmeActionCallback = None
+
 		# Add handler for supported device management commands
 		self.client.message_callback_add("iotdm-1/#", self.__onDeviceMgmtResponse)
 		self.client.message_callback_add(ManagedClient.DM_REBOOT_TOPIC, self.__onRebootRequest)
@@ -333,16 +336,17 @@ class ManagedClient(Client):
 		self.client.message_callback_add(ManagedClient.DM_FIRMWARE_DOWNLOAD_TOPIC,self.__onFirmwereDownload)
 		self.client.message_callback_add(ManagedClient.DM_UPDATE_TOPIC,self.__onUpdatedDevice)
 		self.client.message_callback_add(ManagedClient.DM_CANCEL_OBSERVE_TOPIC,self.__onFirmwereCancel)
-		
+		self.client.message_callback_add(ManagedClient.DME_ACTION_TOPIC,self.__onDMEActionRequest)
+
 		self.client.on_subscribe = self.on_subscribe
-		
+
 		self.readyForDeviceMgmt = threading.Event()
-		
+
 		# List of DM requests that have not received a response yet
 		self._deviceMgmtRequestsPendingLock = threading.Lock()
 		self._deviceMgmtRequestsPending = {}
 
-		# List of DM notify hook 
+		# List of DM notify hook
 		self._deviceMgmtObservationsLock = threading.Lock()
 		self._deviceMgmtObservations = []
 
@@ -352,11 +356,11 @@ class ManagedClient(Client):
 			self._deviceInfo = deviceInfo
 		else:
 			self._deviceInfo = DeviceInfo()
-		
+
 		self._location = None
 		self._errorCode = None
 		self.__firmwareUpdate = None
-		
+
 		self.manageTimer = None
 
 	def setSerialNumber(self, serialNumber):
@@ -366,7 +370,7 @@ class ManagedClient(Client):
 	def setManufacturer(self, manufacturer):
 		self._deviceInfo.serialNumber = manufacturer
 		return self.notifyFieldChange("deviceInfo.manufacturer", manufacturer)
-	
+
 	def setModel(self, model):
 		self._deviceInfo.serialNumber = model
 		return self.notifyFieldChange("deviceInfo.model", model)
@@ -390,7 +394,7 @@ class ManagedClient(Client):
 	def setDescriptiveLocation(self, descriptiveLocation):
 		self._deviceInfo.descriptiveLocation = descriptiveLocation
 		return self.notifyFieldChange("deviceInfo.descriptiveLocation", descriptiveLocation)
-	
+
 
 	def notifyFieldChange(self, field, value):
 		with self._deviceMgmtObservationsLock:
@@ -398,26 +402,26 @@ class ManagedClient(Client):
 				if not self.readyForDeviceMgmt.wait():
 					self.logger.warning("Unable to notify service of field change because device is not ready for device management")
 					return threading.Event().set()
-		
+
 				reqId = str(uuid.uuid4())
 				message = {
 					"d": {
-						"field": field, 
+						"field": field,
 						"value": value
 					},
 					"reqId": reqId
 				}
-				
+
 				resolvedEvent = threading.Event()
 				self.client.publish(ManagedClient.NOTIFY_TOPIC, payload=json.dumps(message), qos=1, retain=False)
 				with self._deviceMgmtRequestsPendingLock:
 					self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.NOTIFY_TOPIC, "message": message, "event": resolvedEvent}
-				
+
 				return resolvedEvent
 			else:
 				return threading.Event().set()
 	'''
-	This is called after the client has received a CONNACK message from the broker in response to calling connect(). 
+	This is called after the client has received a CONNACK message from the broker in response to calling connect().
 	The parameter rc is an integer giving the return code:
 	0: Success
 	1: Refused - unacceptable protocol version
@@ -431,57 +435,64 @@ class ManagedClient(Client):
 			self.connectEvent.set()
 			self.logger.info("Connected successfully: %s" % self.clientId)
 			if self._options['org'] != "quickstart":
-				self.client.subscribe( [(ManagedClient.DM_RESPONSE_TOPIC, 1), (ManagedClient.DM_OBSERVE_TOPIC, 1),(ManagedClient.DM_REBOOT_TOPIC,1),(ManagedClient.DM_FACTORY_REESET,1),(ManagedClient.DM_UPDATE_TOPIC,1), (ManagedClient.DM_FIRMWARE_UPDATE_TOPIC,1),(ManagedClient.DM_FIRMWARE_DOWNLOAD_TOPIC,1),(ManagedClient.DM_CANCEL_OBSERVE_TOPIC,1),(Client.COMMAND_TOPIC, 1)] )
+				self.client.subscribe( [(ManagedClient.DM_RESPONSE_TOPIC, 1), (ManagedClient.DM_OBSERVE_TOPIC, 1),
+				(ManagedClient.DM_REBOOT_TOPIC,1),(ManagedClient.DM_FACTORY_REESET,1),(ManagedClient.DM_UPDATE_TOPIC,1),
+				(ManagedClient.DM_FIRMWARE_UPDATE_TOPIC,1),(ManagedClient.DM_FIRMWARE_DOWNLOAD_TOPIC,1),
+				(ManagedClient.DM_CANCEL_OBSERVE_TOPIC,1),(Client.COMMAND_TOPIC, 1),(ManagedClient.DME_ACTION_TOPIC,1)] )
 		elif rc == 5:
 			self.logAndRaiseException(ConnectionException("Not authorized: s (%s, %s, %s)" % (self.clientId, self.username, self.password)))
 		else:
 			self.logAndRaiseException(ConnectionException("Connection failed: RC= %s" % (rc)))
-	
-	
+
+
 	def on_subscribe(self, client, userdata, mid, granted_qos):
-		# Once IoTF acknowledges the subscriptions we are able to process commands and responses from device management server 
+		# Once IoTF acknowledges the subscriptions we are able to process commands and responses from device management server
 		self.subscriptionsAcknowledged.set()
 		self.manage()
-	
-	
-	def manage(self, lifetime=3600, supportDeviceActions=True, supportFirmwareActions=True):
+
+
+	def manage(self, lifetime=3600, supportDeviceActions=True, supportFirmwareActions=True,
+					supportDeviceMgmtExtActions=False, bundleId=None):
 		# TODO: throw an error, minimum lifetime this client will support is 1 hour, but for now set lifetime to infinite if it's invalid
 		if lifetime < 3600:
 			lifetime = 0
-		
+
 		if not self.subscriptionsAcknowledged.wait():
 			self.logger.warning("Unable to send register for device management because device subscriptions are not in place")
 			return threading.Event().set()
-		
+
 		reqId = str(uuid.uuid4())
 		message = {
-			'd': {
-				"lifetime": lifetime,
-				"supports": {
-					"deviceActions": supportDeviceActions,
-					"firmwareActions": supportFirmwareActions
-				},
-				"deviceInfo" : self._deviceInfo.__dict__,
-				"metadata" : self.metadata
-			},
-			'reqId': reqId
-		}
-		
+					'd': {
+							"lifetime": lifetime,
+							"supports": {
+											"deviceActions": supportDeviceActions,
+											"firmwareActions": supportFirmwareActions,
+										},
+							"deviceInfo" : self._deviceInfo.__dict__,
+							"metadata" : self.metadata
+						},
+					'reqId': reqId
+				}
+		if supportDeviceMgmtExtActions and bundleId is not None:
+			message['d']['supports'][bundleId] = supportDeviceMgmtExtActions
+
 		resolvedEvent = threading.Event()
 		self.client.publish(ManagedClient.MANAGE_TOPIC, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.MANAGE_TOPIC, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.MANAGE_TOPIC, "message": message, "event": resolvedEvent}
+
 		# Register the future call back to IoT Foundation 2 minutes before the device lifetime expiry
 		if lifetime != 0:
 			if self.manageTimer is not None:
 				self._logger.debug("Cancelling existing manage timer")
 				self.manageTimer.cancel()
-			self.manageTimer = threading.Timer(lifetime-120, self.manage, [lifetime, supportDeviceActions, supportFirmwareActions]).start()
-	
+			self.manageTimer = threading.Timer(lifetime-120, self.manage,
+		    [lifetime, supportDeviceActions, supportFirmwareActions, supportDeviceMgmtExtActions, bundleId]).start()
+
 		return resolvedEvent
-	
-	
+
+
 	def unmanage(self):
 		if not self.readyForDeviceMgmt.wait():
 			self.logger.warning("Unable to set device to unmanaged because device is not ready for device management")
@@ -491,24 +502,24 @@ class ManagedClient(Client):
 		message = {
 			'reqId': reqId
 		}
-		
+
 		resolvedEvent = threading.Event()
 		self.client.publish(ManagedClient.UNMANAGE_TOPIC, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.UNMANAGE_TOPIC, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.UNMANAGE_TOPIC, "message": message, "event": resolvedEvent}
+
 		return resolvedEvent
-	
+
 	def setLocation(self, longitude, latitude, elevation=None, accuracy=None):
 		# TODO: Add validation (e.g. ensure numeric values)
 		if self._location is None:
 			self._location = {}
-		
+
 		self._location['longitude'] = longitude
 		self._location['latitude'] = latitude
 		if elevation:
 			self._location['elevation'] = elevation
-		
+
 		self._location['measuredDateTime'] = datetime.now(pytz.timezone('UTC')).isoformat()
 
 		if accuracy:
@@ -525,21 +536,21 @@ class ManagedClient(Client):
 			"d": self._location,
 			"reqId": reqId
 		}
-		
+
 		resolvedEvent = threading.Event()
 		self.client.publish(ManagedClient.UPDATE_LOCATION_TOPIC, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
 			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.UPDATE_LOCATION_TOPIC, "message": message, "event": resolvedEvent}
-		
+
 		return resolvedEvent
-	
-	
+
+
 	def setErrorCode(self, errorCode=0):
 		if errorCode is None:
 			errorCode = 0;
-			
+
 		self._errorCode = errorCode
-		
+
 		if not self.readyForDeviceMgmt.wait():
 			self.logger.warning("Unable to publish error code because device is not ready for device management")
 			return threading.Event().set()
@@ -549,17 +560,17 @@ class ManagedClient(Client):
 			"d": { "errorCode": errorCode },
 			"reqId": reqId
 		}
-		
+
 		resolvedEvent = threading.Event()
 		self.client.publish(ManagedClient.ADD_ERROR_CODE_TOPIC, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.ADD_ERROR_CODE_TOPIC, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.ADD_ERROR_CODE_TOPIC, "message": message, "event": resolvedEvent}
+
 		return resolvedEvent
 
 	def clearErrorCodes(self):
 		self._errorCode = None
-		
+
 		if not self.readyForDeviceMgmt.wait():
 			self.logger.warning("Unable to clear error codes because device is not ready for device management")
 			return threading.Event().set()
@@ -568,14 +579,14 @@ class ManagedClient(Client):
 		message = {
 			"reqId": reqId
 		}
-		
+
 		resolvedEvent = threading.Event()
 		self.client.publish(ManagedClient.CLEAR_ERROR_CODES_TOPIC, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.CLEAR_ERROR_CODES_TOPIC, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.CLEAR_ERROR_CODES_TOPIC, "message": message, "event": resolvedEvent}
+
 		return resolvedEvent
-	
+
 	def addLog(self, msg="",data="",sensitivity=0):
 		timestamp = datetime.now().isoformat()
 		if not self.readyForDeviceMgmt.wait():
@@ -584,7 +595,7 @@ class ManagedClient(Client):
 
 		reqId = str(uuid.uuid4())
 		message = {
-			"d": {  
+			"d": {
 				"message": msg,
                 "timestamp": timestamp,
                 "data": data,
@@ -592,16 +603,16 @@ class ManagedClient(Client):
                  },
 			"reqId": reqId
 		}
-		
+
 		resolvedEvent = threading.Event()
 		self.client.publish(ManagedClient.ADD_LOG_TOPIC, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.ADD_LOG_TOPIC, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.ADD_LOG_TOPIC, "message": message, "event": resolvedEvent}
+
 		return resolvedEvent
 
 	def clearLog(self):
-		
+
 		if not self.readyForDeviceMgmt.wait():
 			self.logger.warning("Unable to clear log because device is not ready for device management")
 			return threading.Event().set()
@@ -610,20 +621,20 @@ class ManagedClient(Client):
 		message = {
 			"reqId": reqId
 		}
-		
+
 		resolvedEvent = threading.Event()
 		self.client.publish(ManagedClient.CLEAR_LOG_TOPIC, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.CLEAR_LOG_TOPIC, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": ManagedClient.CLEAR_LOG_TOPIC, "message": message, "event": resolvedEvent}
+
 		return resolvedEvent
-	
-	
+
+
 	def __onDeviceMgmtResponse(self, client, userdata, pahoMessage):
-		
+
 		with self._recvLock:
 			self.recv = self.recv + 1
-		
+
 		try:
 			data = json.loads(pahoMessage.payload.decode("utf-8"))
 			if 'rc' not in data:
@@ -641,25 +652,25 @@ class ManagedClient(Client):
 					self.logger.warning("Received unexpected response from device management: %s" % (reqId))
 				else:
 					self.logger.debug("Remaining unprocessed device management requests: %s" % (len(self._deviceMgmtRequestsPending)))
-					
-			
+
+
 			if request is None:
 				return False
-				
+
 			if request['topic'] == ManagedClient.MANAGE_TOPIC:
 				if rc == 200:
 					self.logger.info("[%s] Manage action completed: %s" % (rc, json.dumps(request['message'])))
 					self.readyForDeviceMgmt.set()
 				else:
 					self.logger.critical("[%s] Manage action failed: %s" % (rc, json.dumps(request['message'])))
-					
+
 			elif request['topic'] == ManagedClient.UNMANAGE_TOPIC:
 				if rc == 200:
 					self.logger.info("[%s] Unmanage action completed: %s" % (rc, json.dumps(request['message'])))
 					self.readyForDeviceMgmt.clear()
 				else:
 					self.logger.critical("[%s] Unmanage action failed: %s" % (rc, json.dumps(request['message'])))
-			
+
 			elif request['topic'] == ManagedClient.UPDATE_LOCATION_TOPIC:
 				if rc == 200:
 					self.logger.info("[%s] Location update action completed: %s" % (rc, json.dumps(request['message'])))
@@ -677,26 +688,25 @@ class ManagedClient(Client):
 					self.logger.info("[%s] Clear error codes action completed: %s" % (rc, json.dumps(request['message'])))
 				else:
 					self.logger.critical("[%s] Clear error codes action failed: %s" % (rc, json.dumps(request['message'])))
-			
+
 			elif request['topic'] == ManagedClient.ADD_LOG_TOPIC:
 				if rc == 200:
 					self.logger.info("[%s] Add log action completed: %s" % (rc, json.dumps(request['message'])))
 				else:
 					self.logger.critical("[%s] Add log action failed: %s" % (rc, json.dumps(request['message'])))
-			
+
 			elif request['topic'] == ManagedClient.CLEAR_LOG_TOPIC:
 				if rc == 200:
 					self.logger.info("[%s] Clear log action completed: %s" % (rc, json.dumps(request['message'])))
 				else:
 					self.logger.critical("[%s] Clear log action failed: %s" % (rc, json.dumps(request['message'])))
-			
-			else:		
+			else:
 				self.logger.warning("[%s] Unknown action response: %s" % (rc, json.dumps(request['message'])))
-			
+
 			# Now clear the event, allowing anyone that was waiting on this to proceed
 			request["event"].set()
 			return True
-		
+
 	#Device Action Handlers
 	def __onRebootRequest(self,client,userdata,pahoMessage):
 		self.logger.info("Message received on topic :%s with payload %s" % (ManagedClient.DM_REBOOT_TOPIC,pahoMessage.payload.decode("utf-8")))
@@ -706,7 +716,7 @@ class ManagedClient(Client):
 			if self.deviceActionCallback : self.deviceActionCallback(reqId,"reboot")
 		except ValueError as e:
 			raise Exception("Unable to process Reboot request.  payload=\"%s\" error=%s" % (pahoMessage.payload, str(e)))
-	
+
 	def __onFactoryResetRequest(self,client,userdata,pahoMessage):
 		self.logger.info("Message received on topic :%s with payload %s" % (ManagedClient.DM_FACTORY_REESET,pahoMessage.payload.decode("utf-8")))
 		try:
@@ -715,7 +725,7 @@ class ManagedClient(Client):
 			if self.deviceActionCallback : self.deviceActionCallback(reqId,"reset")
 		except ValueError as e:
 			raise Exception("Unable to process Factory Reset request.  payload=\"%s\" error=%s" % (pahoMessage.payload, str(e)))
-		
+
 	def respondDeviceAction(self,reqId,responseCode=202,message=""):
 		response ={
 				        "rc": responseCode,
@@ -737,24 +747,24 @@ class ManagedClient(Client):
 			rc = ManagedClient.RESPONSECODE_BAD_REQUEST
 			msg = "Cannot download as the device is not in idle state"
 		threading.Thread(target= self.respondDeviceAction,args=(reqId,rc,msg)).start()
-		if self.firmwereActionCallback : 
+		if self.firmwereActionCallback :
 			self.firmwereActionCallback("download",self.__firmwareUpdate)
 
-			
+
 	def __onFirmwereCancel(self,client,userdata,pahoMessage):
 		self.logger.info("Message received on topic :%s with payload %s" % (ManagedClient.DM_CANCEL_OBSERVE_TOPIC,pahoMessage.payload.decode("utf-8")))
 		data = json.loads(pahoMessage.payload.decode("utf-8"))
 		reqId = data['reqId']
 		threading.Thread(target= self.respondDeviceAction,args=(reqId,200,"")).start()
-		
+
 	def __onFirmwereObserve(self,client,userdata,pahoMessage):
 		self.logger.info("Message received on topic :%s with payload %s" % (ManagedClient.DM_OBSERVE_TOPIC,pahoMessage.payload.decode("utf-8")))
 		data = json.loads(pahoMessage.payload.decode("utf-8"))
 		reqId = data['reqId']
 		#TODO : Proprer validation for fields in payload
 		threading.Thread(target= self.respondDeviceAction,args=(reqId,200,"")).start()
-		
-	def __onUpdatedDevice(self,client,userdata,pahoMessage):	
+
+	def __onUpdatedDevice(self,client,userdata,pahoMessage):
 		self.logger.info("Message received on topic :%s with payload %s" % (ManagedClient.DM_UPDATE_TOPIC,pahoMessage.payload.decode("utf-8")))
 		data = json.loads(pahoMessage.payload.decode("utf-8"))
 		reqId = data['reqId']
@@ -767,24 +777,24 @@ class ManagedClient(Client):
 		if value != None :
 			self.__firmwareUpdate = DeviceFirmware(value['version'],value['name'],value['uri'],value['verifier'],value['state'],value['updateStatus'],value['updatedDateTime'])
 		threading.Thread(target= self.respondDeviceAction,args=(reqId,204,"")).start()
-	
+
 	def setState(self,status):
 		notify = {"d":{"fields":[{"field":"mgmt.firmware","value":{"state":status}}]}}
 		if self.__firmwareUpdate != None :
 			self.__firmwareUpdate.state = status
-			
-		self.logger.info("Publishing state Update with payload :%s" % json.dumps(notify))	
+
+		self.logger.info("Publishing state Update with payload :%s" % json.dumps(notify))
 		threading.Thread(target= self.client.publish,args=('iotdevice-1/notify',json.dumps(notify),1, False)).start()
-	
+
 	def setUpdateStatus(self,status):
 		notify = {"d":{"fields":[{"field":"mgmt.firmware","value":{"state":ManagedClient.UPDATESTATE_IDLE,"updateStatus":status}}]}}
 		if self.__firmwareUpdate != None :
 			self.__firmwareUpdate.state = ManagedClient.UPDATESTATE_IDLE
 			self.__firmwareUpdate.updateStatus = status
-			
-		self.logger.info("Publishing  Update Status  with payload :%s" % json.dumps(notify))	
-		threading.Thread(target= self.client.publish,args=('iotdevice-1/notify',json.dumps(notify),1, False)).start() 
-		
+
+		self.logger.info("Publishing  Update Status  with payload :%s" % json.dumps(notify))
+		threading.Thread(target= self.client.publish,args=('iotdevice-1/notify',json.dumps(notify),1, False)).start()
+
 	def __onFirmwereUpdate(self,client,userdata,pahoMessage):
 		self.logger.info("Message received on topic :%s with payload %s" % (ManagedClient.DM_FIRMWARE_UPDATE_TOPIC,pahoMessage.payload.decode("utf-8")))
 		data = json.loads(pahoMessage.payload.decode("utf-8"))
@@ -794,11 +804,25 @@ class ManagedClient(Client):
 		if self.__firmwareUpdate.state != ManagedClient.UPDATESTATE_DOWNLOADED :
 			rc = ManagedClient.RESPONSECODE_BAD_REQUEST
 			msg = "Firmware is still not successfully downloaded."
-		threading.Thread(target= self.respondDeviceAction,args=(reqId,rc,msg)).start() 
-		if self.firmwereActionCallback : 
+		threading.Thread(target= self.respondDeviceAction,args=(reqId,rc,msg)).start()
+		if self.firmwereActionCallback :
 			self.firmwereActionCallback("update",self.__firmwareUpdate)
-	
 
+	def __onDMEActionRequest(self,client,userdata,pahoMessage):
+		data = json.loads(pahoMessage.payload.decode("utf-8"))
+		self.logger.info("Message received on topic :%s with payload %s"
+		      % (ManagedClient.DME_ACTION_TOPIC,data))
+		reqId = data['reqId']
+		if self.dmeActionCallback :
+			if self.dmeActionCallback(pahoMessage.topic,data,reqId):
+				msg = "DME Action successfully completed from Callback"
+			   	threading.Thread(target= self.respondDeviceAction,args=(reqId,200,msg)).start()
+		   	else:
+				msg = "Unexpected device error"
+			   	threading.Thread(target= self.respondDeviceAction,args=(reqId,500,msg)).start()
+
+		else :
+			threading.Thread(target= self.respondDeviceAction,args=(reqId,501,"Operation not implemented")).start()
 
 
 def ParseConfigFile(configFilePath):
@@ -813,7 +837,7 @@ def ParseConfigFile(configFilePath):
 				# Python 2.7 support
 				# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file
 				parms.readfp(f)
-				
+
 		domain = parms.get(sectionHeader, "domain")
 		organization = parms.get(sectionHeader, "org")
 		deviceType = parms.get(sectionHeader, "type")
@@ -821,9 +845,9 @@ def ParseConfigFile(configFilePath):
 		authMethod = parms.get(sectionHeader, "auth-method")
 		authToken = parms.get(sectionHeader, "auth-token")
 		cleanSession = parms.get(sectionHeader, "clean-session")
-				
+
 	except IOError as e:
 		reason = "Error reading device configuration file '%s' (%s)" % (configFilePath,e[1])
 		raise ConfigurationException(reason)
-		
+
 	return {'domain': domain, 'org': organization, 'type': deviceType, 'id': deviceId, 'auth-method': authMethod, 'auth-token': authToken, 'clean-session': cleanSession}

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -817,9 +817,9 @@ class ManagedClient(Client):
 			if self.dmeActionCallback(pahoMessage.topic,data,reqId):
 				msg = "DME Action successfully completed from Callback"
 				threading.Thread(target= self.respondDeviceAction,args=(reqId,200,msg)).start()
-		   	else:
+			else:
 				msg = "Unexpected device error"
-			   	threading.Thread(target= self.respondDeviceAction,args=(reqId,500,msg)).start()
+				threading.Thread(target= self.respondDeviceAction,args=(reqId,500,msg)).start()
 
 		else :
 			threading.Thread(target= self.respondDeviceAction,args=(reqId,501,"Operation not implemented")).start()

--- a/src/ibmiotf/gateway.py
+++ b/src/ibmiotf/gateway.py
@@ -4,7 +4,7 @@
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html 
+# http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
 #   Amit M Mangalvedkar  - Initial Contribution
@@ -55,7 +55,7 @@ class Command:
 
 
 class Client(AbstractClient):
-	
+
 	COMMAND_TOPIC = "iot-2/type/+/id/+/cmd/+/fmt/+"
 
 	def __init__(self, options, logHandlers=None):
@@ -64,30 +64,30 @@ class Client(AbstractClient):
 		if "domain" not in self._options:
 			# Default to the domain for the public cloud offering
 			self._options['domain'] = "internetofthings.ibmcloud.com"
-		
+
 		if self._options['org'] == None:
 			raise ConfigurationException("Missing required property: org")
-		if self._options['type'] == None: 
+		if self._options['type'] == None:
 			raise ConfigurationException("Missing required property: type")
-		if self._options['id'] == None: 
+		if self._options['id'] == None:
 			raise ConfigurationException("Missing required property: id")
-				
+
 		if self._options['org'] != "quickstart":
-			if self._options['auth-method'] == None: 
+			if self._options['auth-method'] == None:
 				raise ConfigurationException("Missing required property: auth-method")
-				
+
 			if (self._options['auth-method'] == "token"):
-				if self._options['auth-token'] == None: 
+				if self._options['auth-token'] == None:
 					raise ConfigurationException("Missing required property for token based authentication: auth-token")
 			else:
 				raise UnsupportedAuthenticationMethod(options['authMethod'])
 		self._options['subscriptionList'] = {}
-		
+
 		AbstractClient.__init__(
-			self, 
+			self,
 			domain = self._options['domain'],
 			organization = self._options['org'],
-			clientId = "g:" + self._options['org'] + ":" + self._options['type'] + ":" + self._options['id'], 
+			clientId = "g:" + self._options['org'] + ":" + self._options['type'] + ":" + self._options['id'],
 			username = "use-token-auth" if (self._options['auth-method'] == "token") else None,
 			password = self._options['auth-token'],
 			logHandlers = logHandlers
@@ -102,10 +102,10 @@ class Client(AbstractClient):
 			self.client.message_callback_add(gatewayCommandTopic, self.__onCommand)
 			self.client.message_callback_add("iot-2/type/+/id/+/cmd/+/fmt/+", self.__onDeviceCommand)
 			self.client.message_callback_add(messageNotificationTopic, self.__onMessageNotification)
-			
+
 
 		self.subscriptionsAcknowledged = threading.Event()
-		
+
 		# Initialize user supplied callback
 		self.commandCallback = None
 		self.deviceCommandCallback = None
@@ -113,15 +113,15 @@ class Client(AbstractClient):
 		self.client.on_connect = self.on_connect
 		self.setMessageEncoderModule('json', jsonCodec)
 		self.setMessageEncoderModule('json-iotf', jsonIotfCodec)
-		
+
 		# Create api key for gateway authentication
 		self.gatewayApiKey = "g/" + self._options['org'] + '/' + self._options['type'] + '/' + self._options['id']
 		self.logger = logging.getLogger(self.__module__+"."+self.__class__.__name__)
 		self.logger.setLevel(logging.INFO)
 		self.apiClient = api.ApiClient({"org": self._options['org'], "auth-token": self._options['auth-token'], "auth-key": self.gatewayApiKey },self.logger)
-	
+
 	'''
-	This is called after the client has received a CONNACK message from the broker in response to calling connect(). 
+	This is called after the client has received a CONNACK message from the broker in response to calling connect().
 	The parameter rc is an integer giving the return code:
 	0: Success
 	1: Refused - unacceptable protocol version
@@ -141,15 +141,15 @@ class Client(AbstractClient):
 		else:
 			self.logAndRaiseException(ConnectionException("Connection failed: RC= %s" % (rc)))
 
-	
+
 	'''
-	Publish an event in Watson IoT.  
+	Publish an event in Watson IoT.
 	Parameters:
 		event - the name of this event
 		msgFormat - the format of the data for this event
 		data - the data for this event
 		deviceType - the device type of the device on the behalf of which the gateway is publishing the event
-		
+
 	Optional paramters:
 		qos - the equivalent MQTT semantics of quality of service using the same constants (0, 1 and 2)
 		on_publish - a function that will be called when receipt of the publication is confirmed.  This
@@ -164,15 +164,15 @@ class Client(AbstractClient):
 		else:
 			self.logger.debug("Sending event %s with data %s" % (event, json.dumps(data)))
 			topic = 'iot-2/type/' + deviceType + '/id/' + deviceId +'/evt/'+event+'/fmt/' + msgFormat
-			
+
 			if msgFormat in self._messageEncoderModules:
 				payload = self._messageEncoderModules[msgFormat].encode(data, datetime.now(pytz.timezone('UTC')))
-				
+
 				try:
 					# need to take lock to ensure on_publish is not called before we know the mid
 					if on_publish is not None:
 						self._messagesLock.acquire()
-					
+
 					result = self.client.publish(topic, payload=payload, qos=qos, retain=False)
 					if result[0] == paho.MQTT_ERR_SUCCESS:
 						if on_publish is not None:
@@ -188,7 +188,7 @@ class Client(AbstractClient):
 
 
 	'''
-	Publish an event in Watson IoT as a device.  
+	Publish an event in Watson IoT as a device.
 	Parameters:
 		event - the name of this event
 		msgFormat - the format of the data for this event
@@ -213,12 +213,12 @@ class Client(AbstractClient):
 
 			if msgFormat in self._messageEncoderModules:
 				payload = self._messageEncoderModules[msgFormat].encode(data, datetime.now(pytz.timezone('UTC')))
-				
+
 				try:
 					# need to take lock to ensure on_publish is not called before we know the mid
 					if on_publish is not None:
 						self._messagesLock.acquire()
-					
+
 					result = self.client.publish(topic, payload=payload, qos=qos, retain=False)
 					if result[0] == paho.MQTT_ERR_SUCCESS:
 						if on_publish is not None:
@@ -250,7 +250,7 @@ class Client(AbstractClient):
 		orgid = self._options['org']
 		deviceType = self._options['type']
 		deviceId = self._options['id']
-		authMethod = self._options['auth-method'] 
+		authMethod = self._options['auth-method']
 		authToken = self._options['auth-token']
 		credentials = (authMethod, authToken)
 
@@ -268,7 +268,7 @@ class Client(AbstractClient):
 			response = requests.post(intermediateUrl, auth = credentials, data = payload, headers = {'content-type': 'application/json'})
 		except Exception as e:
 			self.logger.error("POST Failed")
-			self.logger.error(e)			
+			self.logger.error(e)
 			raise ConnectionException("Server not found")
 
 		if response.status_code >= 300:
@@ -279,7 +279,7 @@ class Client(AbstractClient):
 		if self._options['org'] == "quickstart":
 			self.logger.warning("QuickStart not supported in Gateways")
 			return False
-		
+
 		if not self.connectEvent.wait():
 			self.logger.warning("Unable to subscribe to device commands because gateway is not currently connected")
 			return False
@@ -306,7 +306,7 @@ class Client(AbstractClient):
 			self._options['subscriptionList'][topic] = qos
 			return True
 
-		
+
 	def subscribeToGatewayNotifications(self):
 		deviceType = self._options['type']
 		deviceId = self._options['id']
@@ -321,10 +321,10 @@ class Client(AbstractClient):
 			self.client.subscribe(topic)
 			#self._options['subscriptionList'][topic] = qos
 			return True
-		
+
 
 	'''
-	Internal callback for device command messages, parses source device from topic string and 
+	Internal callback for device command messages, parses source device from topic string and
 	passes the information on to the registered device command callback
 	'''
 	def __onCommand(self, client, userdata, pahoMessage):
@@ -339,7 +339,7 @@ class Client(AbstractClient):
 			if self.commandCallback: self.commandCallback(command)
 
 	'''
-	Internal callback for gateway command messages, parses source device from topic string and 
+	Internal callback for gateway command messages, parses source device from topic string and
 	passes the information on to the registered device command callback
 	'''
 	def __onDeviceCommand(self, client, userdata, pahoMessage):
@@ -354,7 +354,7 @@ class Client(AbstractClient):
 			if self.deviceCommandCallback: self.deviceCommandCallback(command)
 
 	'''
-	Internal callback for gateway notification messages, parses source device from topic string and 
+	Internal callback for gateway notification messages, parses source device from topic string and
 	passes the information on to the registered device command callback
 	'''
 	def __onMessageNotification(self, client, userdata, pahoMessage):
@@ -380,11 +380,11 @@ class DeviceInfo(object):
 		self.fwVersion = None
 		self.hwVersion = None
 		self.descriptiveLocation = None
-	
+
 	def __str__(self):
 		return json.dumps(self.__dict__, sort_keys=True)
-	
-	
+
+
 class ManagedGateway(Client):
 
 	# Publish MQTT topics
@@ -395,7 +395,7 @@ class ManagedGateway(Client):
 	ADD_ERROR_CODE_TOPIC = 'iotdevice-1/add/diag/errorCodes'
 	CLEAR_ERROR_CODES_TOPIC = 'iotdevice-1/clear/diag/errorCodes'
 	NOTIFY_TOPIC = 'iotdevice-1/notify'
-	
+
 	# Subscribe MQTT topics
 	DM_RESPONSE_TOPIC = 'iotdm-1/response'
 	DM_OBSERVE_TOPIC = 'iotdm-1/observe'
@@ -407,29 +407,29 @@ class ManagedGateway(Client):
 	ADD_ERROR_CODE_TOPIC_TEMPLATE = 'iotdevice-1/type/%s/id/%s/add/diag/errorCodes'
 	CLEAR_ERROR_CODES_TOPIC_TEMPLATE = 'iotdevice-1/type/%s/id/%s/clear/diag/errorCodes'
 	NOTIFY_TOPIC_TEMPLATE = 'iotdevice-1/type/%s/id/%s/notify'
-	
+
 	# Subscribe MQTT topics
 	DM_RESPONSE_TOPIC_TEMPLATE = 'iotdm-1/type/%s/id/%s/response'
 	DM_OBSERVE_TOPIC_TEMPLATE = 'iotdm-1/type/%s/id/%s/observe'
-	
+
 	def __init__(self, options, logHandlers=None, deviceInfo=None):
 		if options['org'] == "quickstart":
 			raise Exception("Unable to create ManagedGateway instance.  QuickStart devices do not support device management")
 
 		Client.__init__(self, options, logHandlers)
 		# TODO: Raise fatal exception if tries to create managed device client for QuickStart
-		
+
 		# Add handler for supported device management commands
 		self.client.message_callback_add("iotdm-1/#", self.__onDeviceMgmtResponse)
 		self.client.on_subscribe = self.on_subscribe
-		
+
 		self.readyForDeviceMgmt = threading.Event()
-		
+
 		# List of DM requests that have not received a response yet
 		self._deviceMgmtRequestsPendingLock = threading.Lock()
 		self._deviceMgmtRequestsPending = {}
 
-		# List of DM notify hook 
+		# List of DM notify hook
 		self._deviceMgmtObservationsLock = threading.Lock()
 		self._deviceMgmtObservations = []
 
@@ -439,10 +439,10 @@ class ManagedGateway(Client):
 			self._deviceInfo = deviceInfo
 		else:
 			self._deviceInfo = DeviceInfo()
-		
+
 		self._location = None
 		self._errorCode = None
-	
+
 		self._gatewayType = self._options['type']
 		self._gatewayId = self._options['id']
 
@@ -454,7 +454,7 @@ class ManagedGateway(Client):
 	def setManufacturer(self, manufacturer):
 		self._deviceInfo.serialNumber = manufacturer
 		return self.notifyFieldChange("deviceInfo.manufacturer", manufacturer)
-	
+
 	def setModel(self, model):
 		self._deviceInfo.serialNumber = model
 		return self.notifyFieldChange("deviceInfo.model", model)
@@ -478,7 +478,7 @@ class ManagedGateway(Client):
 	def setDescriptiveLocation(self, descriptiveLocation):
 		self._deviceInfo.descriptiveLocation = descriptiveLocation
 		return self.notifyFieldChange("deviceInfo.descriptiveLocation", descriptiveLocation)
-	
+
 
 	def notifyFieldChange(self, field, value):
 		with self._deviceMgmtObservationsLock:
@@ -486,23 +486,23 @@ class ManagedGateway(Client):
 				if not self.readyForDeviceMgmt.wait():
 					self.logger.warning("Unable to notify service of field change because gateway is not ready for gateway management")
 					return threading.Event().set()
-		
+
 				reqId = str(uuid.uuid4())
 				message = {
 					"d": {
-						"field": field, 
+						"field": field,
 						"value": value
 					},
 					"reqId": reqId
 				}
-				
-				notify_topic = ManagedGateway.NOTIFY_TOPIC_TEMPLATE %  (self._gatewayType,self._gatewayId)				
+
+				notify_topic = ManagedGateway.NOTIFY_TOPIC_TEMPLATE %  (self._gatewayType,self._gatewayId)
 				resolvedEvent = threading.Event()
-				
+
 				self.client.publish(notify_topic, payload=json.dumps(message), qos=1, retain=False)
 				with self._deviceMgmtRequestsPendingLock:
 					self._deviceMgmtRequestsPending[reqId] = {"topic": notify_topic, "message": message, "event": resolvedEvent}
-				
+
 				return resolvedEvent
 			else:
 				return threading.Event().set()
@@ -519,23 +519,23 @@ class ManagedGateway(Client):
 			self.logAndRaiseException(ConnectionException("Not authorized: s (%s, %s, %s)" % (self.clientId, self.username, self.password)))
 		else:
 			self.logAndRaiseException(ConnectionException("Connection failed: RC= %s" % (rc)))
-	
-	
+
+
 	def on_subscribe(self, client, userdata, mid, granted_qos):
-		# Once Watson IoT acknowledges the subscriptions we are able to process commands and responses from device management server 
+		# Once Watson IoT acknowledges the subscriptions we are able to process commands and responses from device management server
 		self.subscriptionsAcknowledged.set()
 		self.manage()
-	
-	
+
+
 	def manage(self, lifetime=3600, supportDeviceActions=False, supportFirmwareActions=False):
 		# TODO: throw an error, minimum lifetime this client will support is 1 hour, but for now set lifetime to infinite if it's invalid
 		if lifetime < 3600:
 			lifetime = 0
-		
+
 		if not self.subscriptionsAcknowledged.wait():
 			self.logger.warning("Unable to send register for device management because device subscriptions are not in place")
 			return threading.Event().set()
-		
+
 		reqId = str(uuid.uuid4())
 		message = {
 			'd': {
@@ -550,20 +550,20 @@ class ManagedGateway(Client):
 			'reqId': reqId
 		}
 
-		manage_topic = ManagedGateway.MANAGE_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)		
+		manage_topic = ManagedGateway.MANAGE_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)
 		resolvedEvent = threading.Event()
-		
+
 		self.client.publish(manage_topic, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": manage_topic, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": manage_topic, "message": message, "event": resolvedEvent}
+
 		# Register the future call back to IoT Foundation 2 minutes before the device lifetime expiry
 		if lifetime != 0:
 			threading.Timer(lifetime-120, self.manage, [lifetime, supportDeviceActions, supportFirmwareActions]).start()
-		
+
 		return resolvedEvent
-	
-	
+
+
 	def unmanage(self):
 		if not self.readyForDeviceMgmt.wait():
 			self.logger.warning("Unable to set device to unmanaged because device is not ready for device management")
@@ -573,26 +573,26 @@ class ManagedGateway(Client):
 		message = {
 			'reqId': reqId
 		}
-		
+
 		unmanage_topic = ManagedGateway.UNMANAGE_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)
 		resolvedEvent = threading.Event()
-				
+
 		self.client.publish(unmanage_topic, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": unmanage_topic, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": unmanage_topic, "message": message, "event": resolvedEvent}
+
 		return resolvedEvent
-	
+
 	def setLocation(self, longitude, latitude, elevation=None, accuracy=None):
 		# TODO: Add validation (e.g. ensure numeric values)
 		if self._location is None:
 			self._location = {}
-		
+
 		self._location['longitude'] = longitude
 		self._location['latitude'] = latitude
 		if elevation:
 			self._location['elevation'] = elevation
-		
+
 		self._location['measuredDateTime'] = datetime.now(pytz.timezone('UTC')).isoformat()
 
 		if accuracy:
@@ -610,22 +610,22 @@ class ManagedGateway(Client):
 			"reqId": reqId
 		}
 
-		update_location_topic = ManagedGateway.UPDATE_LOCATION_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)		
+		update_location_topic = ManagedGateway.UPDATE_LOCATION_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)
 		resolvedEvent = threading.Event()
 
 		self.client.publish(update_location_topic, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
 			self._deviceMgmtRequestsPending[reqId] = {"topic": update_location_topic, "message": message, "event": resolvedEvent}
-		
+
 		return resolvedEvent
-	
-	
+
+
 	def setErrorCode(self, errorCode=0):
 		if errorCode is None:
 			errorCode = 0;
-			
+
 		self._errorCode = errorCode
-		
+
 		if not self.readyForDeviceMgmt.wait():
 			self.logger.warning("Unable to publish error code because device is not ready for device management")
 			return threading.Event().set()
@@ -636,18 +636,18 @@ class ManagedGateway(Client):
 			"reqId": reqId
 		}
 
-		add_error_code_topic = ManagedGateway.ADD_ERROR_CODE_TOPIC_TEMPLATE %  (self._gatewayType,self._gatewayId)		
+		add_error_code_topic = ManagedGateway.ADD_ERROR_CODE_TOPIC_TEMPLATE %  (self._gatewayType,self._gatewayId)
 		resolvedEvent = threading.Event()
 
 		self.client.publish(add_error_code_topic, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": add_error_code_topic, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": add_error_code_topic, "message": message, "event": resolvedEvent}
+
 		return resolvedEvent
 
 	def clearErrorCodes(self):
 		self._errorCode = None
-		
+
 		if not self.readyForDeviceMgmt.wait():
 			self.logger.warning("Unable to clear error codes because device is not ready for device management")
 			return threading.Event().set()
@@ -656,24 +656,24 @@ class ManagedGateway(Client):
 		message = {
 			"reqId": reqId
 		}
-		
-		clear_error_codes_topic = ManagedGateway.CLEAR_ERROR_CODES_TOPIC_TEMPLATE %  (self._gatewayType,self._gatewayId)		
+
+		clear_error_codes_topic = ManagedGateway.CLEAR_ERROR_CODES_TOPIC_TEMPLATE %  (self._gatewayType,self._gatewayId)
 		resolvedEvent = threading.Event()
 
 		self.client.publish(clear_error_codes_topic, payload=json.dumps(message), qos=1, retain=False)
 		with self._deviceMgmtRequestsPendingLock:
-			self._deviceMgmtRequestsPending[reqId] = {"topic": clear_error_codes_topic, "message": message, "event": resolvedEvent} 
-		
+			self._deviceMgmtRequestsPending[reqId] = {"topic": clear_error_codes_topic, "message": message, "event": resolvedEvent}
+
 		return resolvedEvent
-	
-	
+
+
 	def __onDeviceMgmtResponse(self, client, userdata, pahoMessage):
 		with self._recvLock:
 			self.recv = self.recv + 1
-		
+
 		try:
 			data = json.loads(pahoMessage.payload.decode("utf-8"))
-			
+
 			rc = data['rc']
 			reqId = data['reqId']
 		except ValueError as e:
@@ -687,17 +687,17 @@ class ManagedGateway(Client):
 					self.logger.warning("Received unexpected response from device management: %s" % (reqId))
 				else:
 					self.logger.debug("Remaining unprocessed device management requests: %s" % (len(self._deviceMgmtRequestsPending)))
-					
-			
+
+
 			if request is None:
 				return False
-			
+
 			manage_topic = ManagedGateway.MANAGE_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)
 			unmanage_topic = ManagedGateway.UNMANAGE_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)
 			update_location_topic = ManagedGateway.UPDATE_LOCATION_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)
 			add_error_code_topic = ManagedGateway.ADD_ERROR_CODE_TOPIC_TEMPLATE % (self._gatewayType,self._gatewayId)
 			clear_error_codes_topic = ManagedGateway.CLEAR_ERROR_CODES_TOPIC_TEMPLATE %  (self._gatewayType,self._gatewayId)
-						
+
 			if request['topic'] == manage_topic:
 				if rc == 200:
 					self.logger.info("[%s] Manage action completed: %s" % (rc, json.dumps(request['message'])))
@@ -711,7 +711,7 @@ class ManagedGateway(Client):
 					self.readyForDeviceMgmt.clear()
 				else:
 					self.logger.critical("[%s] Unmanage action failed: %s" % (rc, json.dumps(request['message'])))
-			
+
 			elif request['topic'] == update_location_topic:
 				if rc == 200:
 					self.logger.info("[%s] Location update action completed: %s" % (rc, json.dumps(request['message'])))
@@ -729,18 +729,18 @@ class ManagedGateway(Client):
 					self.logger.info("[%s] Clear error codes action completed: %s" % (rc, json.dumps(request['message'])))
 				else:
 					self.logger.critical("[%s] Clear error codes action failed: %s" % (rc, json.dumps(request['message'])))
-			
-			else:		
+
+			else:
 				self.logger.warning("[%s] Unknown action response: %s" % (rc, json.dumps(request['message'])))
-			
+
 			# Now clear the event, allowing anyone that was waiting on this to proceed
 			request["event"].set()
 			return True
 
-	
+
 
 def ParseConfigFile(configFilePath):
-	parms = configparser.ConfigParser()
+	parms = configparser.ConfigParser({"domain": "internetofthings.ibmcloud.com"})
 	sectionHeader = "device"
 	try:
 		with open(configFilePath) as f:
@@ -764,9 +764,9 @@ def ParseConfigFile(configFilePath):
 				deviceId = parms.get(sectionHeader, "id", None)
 				authMethod = parms.get(sectionHeader, "auth-method", None)
 				authToken = parms.get(sectionHeader, "auth-token", None)
-		
+
 	except IOError as e:
 		reason = "Error reading gateway configuration file '%s' (%s)" % (configFilePath,e[1])
 		raise ConfigurationException(reason)
-		
+
 	return {'domain': domain, 'org': organization, 'type': deviceType, 'id': deviceId, 'auth-method': authMethod, 'auth-token': authToken}

--- a/test/apiTest.py
+++ b/test/apiTest.py
@@ -1074,23 +1074,8 @@ class TestApi:
         assert_equal(e.exception.msg, 'The device does not exist')
 
     def testDeviceManagementExtensionMethods(self):
-        def doDMEAction(topic,data,reqId):
-            print("In DME Action Callabck")
-            print("Received topic = "+topic)
-            print("Received reqId = "+reqId)
-            print("Received data = %s" %data)
-            return True
-
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token",
            "auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-
-        #Instantiate required device managed client
-        deviceConfFile="device.conf"
-        deviceOptions = ibmiotf.device.ParseConfigFile(deviceConfFile)
-        deviceInfoObj = ibmiotf.device.DeviceInfo()
-        managedClient = ibmiotf.device.ManagedClient(deviceOptions,deviceInfo=deviceInfoObj)
-        managedClient.connect()
-        managedClient.unmanage()
 
         dmeData = {"bundleId": "example-dme-actions-v1",
                    "displayName": {"en_US": "example-dme Actions v1"},
@@ -1102,18 +1087,8 @@ class TestApi:
         addResult = apiClient.createDeviceManagementExtensionPkg(dmeData)
         assert_equal(addResult['bundleId'],'example-dme-actions-v1')
 
-        managedClient.dmeActionCallback = doDMEAction;
-        managedClient.manage(lifetime=0,supportDeviceMgmtExtActions=True,bundleId='example-dme-actions-v1')
-        mgmtRequest = {"action": "example-dme-actions-v1/installPlugin",
-                       "parameters": [{ "name": "pluginURI",
-                                         "value": "http://example.dme.com",}],
-                       "devices": [{ "typeId": self.deviceType, "deviceId": self.deviceId }]}
-        initResult = apiClient.initiateDeviceManagementRequest(mgmtRequest)
-        reqId = initResult['reqId']
-
         getResult = apiClient.getAllDeviceManagementExtensionPkgs();
         assert_equal(getResult['results'][0]['bundleId'],'edgeanalytics')
-
 
         getResult = apiClient.getDeviceManagementExtensionPkg('example-dme-actions-v1')
         assert_equal(getResult['bundleId'],'example-dme-actions-v1')
@@ -1129,11 +1104,7 @@ class TestApi:
         assert_equal(updResult['version'],'1.1')
 
         assert_true(apiClient.deleteDeviceManagementExtensionPkg('example-dme-actions-v1'))
-        assert_true(apiClient.deleteDeviceManagementRequest(reqId))
-
-        managedClient.unmanage()
-        managedClient.disconnect()
-
+        
     @raises(Exception)
     def testgetAllDeviceManagementExtensionPkgsException(self):
         with assert_raises(APIException) as e:

--- a/test/apiTest.py
+++ b/test/apiTest.py
@@ -4,7 +4,7 @@
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html 
+# http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
 #   Lokesh Haralakatta  - Initial Contribution
@@ -27,18 +27,18 @@ class TestApi:
     authToken=None
     authKey=None
     invalidAuthKey=None
-    
+
     @classmethod
     def setup_class(self):
-        self.logger = logging.getLogger(self.__module__+"."+self.__class__.__name__)
+        self.logger = logging.getLogger(self.__module__+".TestApi")
         self.logger.setLevel(logging.INFO)
-        
+
         appConfFile="application.conf"
         options = ibmiotf.application.ParseConfigFile(appConfFile)
-        
+
         gwayConfFile="gateway.conf"
         gwayOptions = ibmiotf.gateway.ParseConfigFile(gwayConfFile)
-        
+
         self.org = options['auth-key'][2:8]
         self.deviceType = options['type']
         self.gatewayType = gwayOptions['type']
@@ -49,85 +49,85 @@ class TestApi:
         self.newDeviceId = "python-api-test-device"
         self.newDeviceType = "python-api-add-type"
         self.invalidAuthKey = self.authKey[0:9]+"xxxxxxxxxx"
-         
-    @classmethod    
+
+    @classmethod
     def teardown_class(self):
-        self.logger=None        
-    
+        self.logger=None
+
     @raises(Exception)
     def testMissingOptions(self):
         with assert_raises(ConfigurationException) as e:
             ibmiotf.api.ApiClient({},self.logger)
         assert_equal(e.exception.msg, 'Missing required property for API key based authentication: auth-key')
-        
+
     @raises(Exception)
     def testMissingAuthKey(self):
         with assert_raises(ConfigurationException) as e:
-            ibmiotf.api.ApiClient({"org": self.org, "type": self.deviceType, "id": self.deviceId, 
+            ibmiotf.api.ApiClient({"org": self.org, "type": self.deviceType, "id": self.deviceId,
                                         "auth-method": "token" , "auth-token": self.authToken },self.logger)
         assert_equal(e.exception.msg, 'Missing required property for API key based authentication: auth-key')
-    
+
     @raises(Exception)
     def testAuthKeyNone(self):
         with assert_raises(ConfigurationException) as e:
-            ibmiotf.api.ApiClient({"org": self.org, "type": self.deviceType, "id": self.deviceId, 
+            ibmiotf.api.ApiClient({"org": self.org, "type": self.deviceType, "id": self.deviceId,
                                         "auth-method": "token", "auth-token": self.authToken, "auth-key":None},self.logger)
-        assert_equal(e.exception.msg, 'Missing required property for API key based authentication: auth-key')    
-    
+        assert_equal(e.exception.msg, 'Missing required property for API key based authentication: auth-key')
+
     @raises(Exception)
     def testMissingAuthToken(self):
         with assert_raises(ConfigurationException) as e:
-            ibmiotf.api.ApiClient({"org": self.org, "type": self.deviceType, "id": self.deviceId, 
+            ibmiotf.api.ApiClient({"org": self.org, "type": self.deviceType, "id": self.deviceId,
                                    "auth-key": self.authKey },self.logger)
         assert_equal(e.exception.msg, 'Missing required property for API key based authentication: auth-token')
-    
+
     @raises(Exception)
     def testAuthTokenNone(self):
         with assert_raises(ConfigurationException) as e:
             ibmiotf.api.ApiClient({"org":self.org, "type": self.deviceType, "id": self.deviceId,
                                    "auth-token": None, "auth-key":self.authKey},self.logger)
-        assert_equal(e.exception.msg, 'Missing required property for API key based authentication: auth-token')    
-    
+        assert_equal(e.exception.msg, 'Missing required property for API key based authentication: auth-token')
+
     def testGetOrganizationDetails(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
         orgDetails = apiClient.getOrganizationDetails()
         assert_is_instance(orgDetails,dict)
         assert_equal(orgDetails['name'],"Testing Devices Org")
-    
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetOrganizationDetailsInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "invalid-token", "auth-key": self.authKey},self.logger)
             apiClient.getOrganizationDetails()
-        assert_equal(e.exception.msg, 'The authentication token is empty or invalid')        
-    
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
+
+    @raises(Exception)
     def testGetOrganizationDetailsApiKeyNotExist(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getOrganizationDetails()
-        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist') 
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
+
+    @raises(Exception)
     def testGetDevicesUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDevices(parameters=self.deviceId)
         assert_equal(e.exception.msg, 'Unexpected error')
-    
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDevicesInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "invalid-token", "auth-key": self.authKey},self.logger)
             apiClient.getDevices()
-        assert_equal(e.exception.msg, 'The authentication token is empty or invalid')       
-    
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
+
+    @raises(Exception)
     def testGetDevicesInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getDevices()
-        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')    
+        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
 
 
     def testGetDevices(self):
@@ -137,26 +137,26 @@ class TestApi:
         deviceIds = list()
         for item in devicesDetails['results']:
             deviceIds.append(item['deviceId'])
-            
+
         assert_equal(deviceIds.count(self.deviceId),1)
-        assert_equal(deviceIds.count(self.deviceGateway),1)    
-        
-    @raises(Exception)    
+        assert_equal(deviceIds.count(self.deviceGateway),1)
+
+    @raises(Exception)
     def testRegisterDevicesInvalidRequestException(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             devicesList = ["device-1","device-2","device-3"]
             apiClient.registerDevices(devicesList)
-        assert_equal(e.exception.msg, 'Invalid request (No body, invalid JSON, unexpected key, bad value)')    
-    
-    @SkipTest    
+        assert_equal(e.exception.msg, 'Invalid request (No body, invalid JSON, unexpected key, bad value)')
+
+    @SkipTest
     def testRegisterDevicesEmptyDeviceId(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
         devicesList = [{'typeId' : "Python-Api-Test"}]
         registerResult = apiClient.registerDevices(devicesList)
-        assert_false(registerResult[0]['success'])    
-        
-    @raises(Exception)    
+        assert_false(registerResult[0]['success'])
+
+    @raises(Exception)
     def testRegisterDevicesMaxLimitException(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
@@ -166,168 +166,168 @@ class TestApi:
                 devicesList.append(item)
 
             apiClient.registerDevices(devicesList)
-        assert_equal(e.exception.msg, 'Maximum number of devices exceeded')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Maximum number of devices exceeded')
+
+    @raises(Exception)
     def testRegisterDevicesUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.registerDevices(None)
-        assert_equal(e.exception.msg, 'Unexpected error')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Unexpected error')
+
+    @raises(Exception)
     def testRegisterDeviceDuplicate(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.registerDevice(self.deviceType,self.deviceId)
         assert_equal(e.exception.msg, 'The device already exists')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testRegisterDeviceInvalidRequest(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.registerDevice("invalid-type","invalid-device")
         assert_equal(e.exception.msg, 'Invalid request (No body, invalid JSON, unexpected key, bad value)')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testRegisterDeviceInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             apiClient.registerDevice(self.deviceType,self.deviceId)
-        assert_equal(e.exception.msg, 'The authentication token is empty or invalid')     
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
+
+    @raises(Exception)
     def testRegisterDeviceInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.registerDevice(self.deviceType,self.deviceId)
-        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')    
+        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
 
     def testRegisterGetUpdateRemoveDevice(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        location = {"longitude" : "12.78", "latitude" : "45.90", "elevation" : "2000", "accuracy" : "0", 
+        location = {"longitude" : "12.78", "latitude" : "45.90", "elevation" : "2000", "accuracy" : "0",
                     "measuredDateTime" : "2015-10-28T08:45:11.662Z"}
-        deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A", 
+        deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A",
                       "descriptiveLocation" : "Bangalore", "fwVersion" : "1.0.1", "hwVersion" : "12.01"}
         metadata = {"customField1": "customValue3", "customField2": "customValue4"}
-        
+
         #Register new device and validate
         registerResult = apiClient.registerDevice(self.deviceType, self.newDeviceId, self.authToken,deviceInfo, location,metadata)
         assert_equal(registerResult['typeId'],self.deviceType)
         assert_equal(registerResult['deviceId'],self.newDeviceId)
-        
+
         #Get newly registered device
         getResult = apiClient.getDevice(self.deviceType, self.newDeviceId)
         assert_equal(getResult['typeId'],self.deviceType)
         assert_equal(getResult['deviceId'],self.newDeviceId)
-        
+
         #Update device info for newly registered device
-        updDeviceInfo = {"serialNumber": "001", "manufacturer": "Blackberry", "model": "e2", "deviceClass": "A", 
+        updDeviceInfo = {"serialNumber": "001", "manufacturer": "Blackberry", "model": "e2", "deviceClass": "A",
                       "descriptiveLocation" : "ISL Bangalore", "fwVersion" : "1.0.1", "hwVersion" : "12.01"}
         updResult = apiClient.updateDevice(self.deviceType, self.newDeviceId,metadata,updDeviceInfo)
         assert_equal(updResult['typeId'],self.deviceType)
         assert_equal(updResult['deviceId'],self.newDeviceId)
         assert_equal(updResult['deviceInfo']['manufacturer'],"Blackberry")
         assert_equal(updResult['deviceInfo']['descriptiveLocation'],"ISL Bangalore")
-        
+
         #Remove the newly registered device
         assert_true(apiClient.removeDevice(self.deviceType, self.newDeviceId))
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             apiClient.getDevice(self.deviceType,self.newDeviceId)
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getDevice(self.deviceType,self.newDeviceId)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceNotExists(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDevice(self.deviceType,"Device-Not-Exists")
-        assert_equal(e.exception.msg, 'The device does not exist')        
-            
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The device does not exist')
+
+    @raises(Exception)
     def testUpdateDeviceInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             metadata = {"customField1": "customValue3", "customField2": "customValue4"}
             apiClient.updateDevice(self.deviceType,self.newDeviceId,metadata)
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testUpdateDeviceInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             metadata = {"customField1": "customValue3", "customField2": "customValue4"}
             apiClient.updateDevice(self.deviceType,self.newDeviceId,metadata)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testUpdateDeviceNotExists(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             metadata = {"customField1": "customValue3", "customField2": "customValue4"}
             apiClient.updateDevice(self.deviceType,"Device-Not-Exists",metadata)
-        assert_equal(e.exception.msg, 'The device does not exist')        
-    
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The device does not exist')
+
+    @raises(Exception)
     def testUpdateDeviceUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             deviceInfo = {"serialNumber": "001", "manufacturer": "Blackberry"}
             apiClient.updateDevice(self.deviceType,self.newDeviceId,self.authToken,deviceInfo)
         assert_equal(e.exception.msg, 'Unexpected error')
-                
-    @raises(Exception)    
+
+    @raises(Exception)
     def testRemoveDeviceInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             apiClient.removeDevice(self.deviceType,self.deviceId)
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testRemoveDeviceInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.removeDevice(self.deviceType,self.deviceId)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testRemoveDeviceNotExists(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.removeDevice(self.deviceType,"Device-Not-Exists")
-        assert_equal(e.exception.msg, 'The device does not exist')    
-            
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The device does not exist')
+
+    @raises(Exception)
     def testGetDeviceTypesUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceTypes(self.gatewayType)
         assert_equal(e.exception.msg, 'Unexpected error')
-                
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceTypesInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             apiClient.getDeviceTypes()
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceTypesInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getDeviceTypes()
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-    
+
     def testGetDeviceTypes(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
         typesDetails = apiClient.getDeviceTypes()
@@ -335,740 +335,841 @@ class TestApi:
         typesIds = list()
         for item in typesDetails['results']:
             typesIds.append(item['id'])
-            
+
         assert_equal(typesIds.count(self.deviceType),1)
         assert_equal(typesIds.count(self.gatewayType),1)
-        
+
     def testAddGetUpdateDeleteDeviceType(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A", 
+        deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A",
                       "descriptiveLocation" : "Bangalore", "fwVersion" : "1.0.1", "hwVersion" : "12.01"}
         metadata = {"customField1": "customValue3", "customField2": "customValue4"}
-        
+
         #Add new device type
         addResult = apiClient.addDeviceType(self.newDeviceType,"Added by apiClient.addDeviceType Method",deviceInfo,metadata)
         assert_equal(addResult['id'],self.newDeviceType)
-           
-        #Get newly added device type   
+
+        #Get newly added device type
         getResult = apiClient.getDeviceType(self.newDeviceType)
-        assert_equal(getResult['id'],self.newDeviceType) 
-           
-        #Update newly added device type   
-        upd_deviceInfo = {"serialNumber": "001", "manufacturer": "Blackberry", "model": "e2", "deviceClass": "A", 
+        assert_equal(getResult['id'],self.newDeviceType)
+
+        #Update newly added device type
+        upd_deviceInfo = {"serialNumber": "001", "manufacturer": "Blackberry", "model": "e2", "deviceClass": "A",
                       "descriptiveLocation" : "Bangalore", "fwVersion" : "1.0.1", "hwVersion" : "12.01"}
         updResult=apiClient.updateDeviceType(self.newDeviceType, "Added by apiClient.addDeviceType Method",upd_deviceInfo, metadata)
         assert_equal(updResult['deviceInfo']['manufacturer'],"Blackberry")
-           
-        #Remove newly added device type   
+
+        #Remove newly added device type
         assert_true(apiClient.deleteDeviceType(self.newDeviceType))
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testAddDeviceTypeDuplicate(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.addDeviceType(self.deviceType)
         assert_equal(e.exception.msg, 'The device type already exists')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testAddDeviceTypeInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             apiClient.addDeviceType(self.newDeviceType)
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testAddDeviceTypeInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.addDeviceType(self.newDeviceType)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testAddDeviceTypeInvalidRequest(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.addDeviceType(self.newDeviceType,{'description':'newDescription'})
         assert_equal(e.exception.msg, 'Invalid request (No body, invalid JSON, unexpected key, bad value)')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceTypeNotExists(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceType(None)
         assert_equal(e.exception.msg, 'The device type does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceTypeInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             apiClient.getDeviceType(self.newDeviceType)
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceTypeInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getDeviceType(self.newDeviceType)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testUpdateDeviceTypeNotExists(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-            deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A", 
+            deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A",
                       "descriptiveLocation" : "Bangalore", "fwVersion" : "1.0.1", "hwVersion" : "12.01"}
             apiClient.updateDeviceType("type-not-exists","no-decription",deviceInfo)
         assert_equal(e.exception.msg, 'The device type does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testUpdateDeviceTypeInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
-            deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A", 
+            deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A",
                       "descriptiveLocation" : "Bangalore", "fwVersion" : "1.0.1", "hwVersion" : "12.01"}
             apiClient.updateDeviceType(self.newDeviceType,"no-description",deviceInfo)
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testUpdateDeviceTypeInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
-            deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A", 
+            deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A",
                       "descriptiveLocation" : "Bangalore", "fwVersion" : "1.0.1", "hwVersion" : "12.01"}
             apiClient.updateDeviceType(self.newDeviceType,"no-description",deviceInfo)
-        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')    
+        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
 
-    @raises(Exception)    
+    @raises(Exception)
     def testDeleteDeviceTypeInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             apiClient.deleteDeviceType(self.newDeviceType)
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testDeleteDeviceTypeInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.deleteDeviceType(self.newDeviceType)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testDeleteDeviceInvalidAuthToken(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": "x9lB6C9QOb9Hkp0xS", "auth-key": self.authKey},self.logger)
             apiClient.deleteDevice(self.deviceType,self.newDeviceId)
         assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testDeleteDeviceInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.deleteDevice(self.deviceType,self.newDeviceId)
-        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')                            
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
+
+    @raises(Exception)
     def testDeleteDeviceUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.deleteDevice(self.deviceId,self.deviceType)
-        assert_equal(e.exception.msg, 'Unexpected error')    
-        
+        assert_equal(e.exception.msg, 'Unexpected error')
+
     def testDeleteMulitpleDevices(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-                
-        assert_true(apiClient.deleteMultipleDevices([{}])[0]['success'])    
-        
-    @raises(Exception)    
+
+        assert_true(apiClient.deleteMultipleDevices([{}])[0]['success'])
+
+    @raises(Exception)
     def testDeleteMultipleDevicesInvalidBody(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.deleteMultipleDevices(self.deviceType)
-        assert_equal(e.exception.msg, 'Invalid request (No body, invalid JSON, unexpected key, bad value)')    
-    
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Invalid request (No body, invalid JSON, unexpected key, bad value)')
+
+    @raises(Exception)
     def testDeleteMultipleDevicesUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.deleteMultipleDevices(None)
-        assert_equal(e.exception.msg, 'Unexpected error')    
-    
+        assert_equal(e.exception.msg, 'Unexpected error')
+
     @SkipTest
     def testGetLastEvents(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-                
+
         events = apiClient.getLastEvents(self.deviceType,self.deviceId)
         eventId = events[0]['eventId']
-        event = apiClient.getLastEvent(self.deviceType,self.deviceId,eventId)    
+        event = apiClient.getLastEvent(self.deviceType,self.deviceId,eventId)
         assert_equal(event['eventId'],eventId)
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetLastEventUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getLastEvent({"typeId":self.deviceType}, {"deviceId":self.deviceId}, "eventId")
         assert_equal(e.exception.msg, 'Unexpected error')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetLastEventsUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getLastEvent({"typeId":self.deviceType}, {"deviceId":self.deviceId})
         assert_equal(e.exception.msg, 'Unexpected error')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetLastEventNotFoundError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getLastEvent(self.deviceType, self.deviceId, "eventId")
-        assert_equal(e.exception.msg, 'Event not found')            
-        
+        assert_equal(e.exception.msg, 'Event not found')
+
     def testDeviceModelMethods(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        location = {"longitude" : 12.78, "latitude" : 45.90, "elevation" : 2000, "accuracy" : 0, 
+        location = {"longitude" : 12.78, "latitude" : 45.90, "elevation" : 2000, "accuracy" : 0,
                     "measuredDateTime" : "2015-10-28T08:45:11.662Z"}
-        deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A", 
+        deviceInfo = {"serialNumber": "001", "manufacturer": "Blueberry", "model": "e2", "deviceClass": "A",
                       "descriptiveLocation" : "Bangalore", "fwVersion" : "1.0.1", "hwVersion" : "12.01"}
         metadata = {"customField1": "customValue3", "customField2": "customValue4"}
-        
+
         #Register new device and validate
         registerResult = apiClient.registerDevice(self.deviceType, self.newDeviceId, self.authToken,deviceInfo, location,metadata)
         assert_equal(registerResult['typeId'],self.deviceType)
         assert_equal(registerResult['deviceId'],self.newDeviceId)
-        
+
         #Get Device location and validtae the results returned
         locationResult = apiClient.getDeviceLocation(self.deviceType,self.newDeviceId)
         assert_true(locationResult['longitude'] == location['longitude'])
         assert_true(locationResult['latitude'] == location['latitude'])
         assert_true(locationResult['elevation'] == location['elevation'])
         assert_true(locationResult['accuracy'] == location['accuracy'])
-        
+
         #Update Device Location Information
-        location = {"longitude" : 13, "latitude" : 46, "elevation" : 3000, "accuracy" : 100, 
+        location = {"longitude" : 13, "latitude" : 46, "elevation" : 3000, "accuracy" : 100,
                     "measuredDateTime" : "2015-10-28T08:45:11.662Z"}
         updateResult = apiClient.updateDeviceLocation(self.deviceType,self.newDeviceId,location)
         assert_true(updateResult['longitude'] == location['longitude'])
         assert_true(updateResult['latitude'] == location['latitude'])
         assert_true(updateResult['elevation'] == location['elevation'])
         assert_true(updateResult['accuracy'] == location['accuracy'])
-        
+
         #Remove added device using deleteDevice Method
-        assert_true(apiClient.deleteDevice(self.deviceType, self.newDeviceId))    
-        
-    @raises(Exception)    
+        assert_true(apiClient.deleteDevice(self.deviceType, self.newDeviceId))
+
+    @raises(Exception)
     def testGetDeviceLocationNotFoundError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceLocation(self.deviceId,self.deviceType)
-        assert_equal(e.exception.msg, 'Device location information not found')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Device location information not found')
+
+    @raises(Exception)
     def testGetDeviceLocationUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceLocation({"typeId":self.deviceId},self.deviceType)
         assert_equal(e.exception.msg, 'Unexpected error')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testUpdateDeviceLocationNotFoundError(self):
-        location = {"longitude" : "13", "latitude" : "46", "elevation" : "3000", "accuracy" : "100", 
+        location = {"longitude" : "13", "latitude" : "46", "elevation" : "3000", "accuracy" : "100",
                     "measuredDateTime" : "2015-10-28T08:45:11.662Z"}
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.updateDeviceLocation(self.deviceType,"device-not-exists",location)
-        assert_equal(e.exception.msg, 'Device location information not found')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Device location information not found')
+
+    @raises(Exception)
     def testUpdateDeviceLocationUnexpectedError(self):
-        location = {"longitude" : "13", "latitude" : "46", "elevation" : "3000", "accuracy" : "100", 
+        location = {"longitude" : "13", "latitude" : "46", "elevation" : "3000", "accuracy" : "100",
                     "measuredDateTime" : "2015-10-28T08:45:11.662Z"}
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.updateDeviceLocation({"typeId":self.deviceType},self.deviceId,location)
-        assert_equal(e.exception.msg, 'Unexpected error')        
-    
+        assert_equal(e.exception.msg, 'Unexpected error')
+
     @SkipTest
     def testGetDeviceManagementInformation(self):
-        apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)    
+        apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
         apiClient.getDeviceManagementInformation(self.deviceType, self.deviceId)
-             
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceManagementInformationInvalidAuth(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceManagementInformation(self.deviceType, self.deviceId)
-        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
+
+    @raises(Exception)
     def testGetDeviceManagementInformationUnexepctedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceManagementInformation({"typeId":self.deviceType}, self.deviceId)
-        assert_equal(e.exception.msg, 'Unexpected error') 
-        
+        assert_equal(e.exception.msg, 'Unexpected error')
+
     def testGetConnectionLogs(self):
-        apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)    
-        apiClient.getConnectionLogs({"typeId":self.deviceType, "deviceId":self.deviceId})               
-        
-    @raises(Exception)    
+        apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
+        apiClient.getConnectionLogs({"typeId":self.deviceType, "deviceId":self.deviceId})
+
+    @raises(Exception)
     def testGetConnectionLogsUnexepctedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getConnectionLogs(self.deviceType)
-        assert_equal(e.exception.msg, 'Unexpected error')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Unexpected error')
+
+    @raises(Exception)
     def testGetConnectionLogsInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getConnectionLogs({"typeId":self.deviceType, "deviceId":self.deviceId})
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
+
     def testDeviceDiagnosticsLogs(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
         logData = { "message": "sample log entry for python-ut-device","severity": 0,"data": "Diagnostic log entry","timestamp": "2016-05-16T08:44:23.909Z"}
-    
+
         #Clear all diagnostic logs for the device
         assert_true(apiClient.clearAllDiagnosticLogs(self.deviceType, self.deviceId))
-            
+
         #Add one diagnostic log
         assert_true(apiClient.addDiagnosticLog(self.deviceType, self.deviceId, logData))
-          
+
         #Get all diagnostic logs
-        logsData = apiClient.getAllDiagnosticLogs(self.deviceType, self.deviceId) 
+        logsData = apiClient.getAllDiagnosticLogs(self.deviceType, self.deviceId)
         assert_equal(logsData[0]['data'],"Diagnostic log entry")
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetAllDiagnosticLogsDeviceNotFoundError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getAllDiagnosticLogs(self.deviceType,"device-not-exists")
         assert_equal(e.exception.msg, 'Device not found')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetAllDiagnosticLogs500UnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getAllDiagnosticLogs("device-not-exists",self.deviceType)
-        assert_equal(e.exception.msg, '[500] Unexpected error')        
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, '[500] Unexpected error')
+
+    @raises(Exception)
     def testGetAllDiagnosticLogsUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getAllDiagnosticLogs({"typeId":self.deviceType},{"deviceId":self.deviceId})
-        assert_equal(e.exception.msg, 'Unexpected error')    
-    
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Unexpected error')
+
+    @raises(Exception)
     def testClearAllDiagnosticLogsDeviceNotFoundError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.clearAllDiagnosticLogs(self.deviceType,"device-not-exists")
-        assert_equal(e.exception.msg, 'Device not found') 
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Device not found')
+
+    @raises(Exception)
     def testClearAllDiagnosticLogs500UnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.clearAllDiagnosticLogs("device-not-exists",self.deviceType)
-        assert_equal(e.exception.msg, '[500] Unexpected error') 
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, '[500] Unexpected error')
+
+    @raises(Exception)
     def testClearAllDiagnosticLogsUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.clearAllDiagnosticLogs({"typeId":self.deviceType},{"deviceId":self.deviceId})
-        assert_equal(e.exception.msg, 'Unexpected error')          
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Unexpected error')
+
+    @raises(Exception)
     def testClearAllDiagnosticLogsInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.clearAllDiagnosticLogs(self.deviceType, self.deviceId)
-        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')  
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
+
+    @raises(Exception)
     def testAddDiagnosticLogDeviceNotFoundError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             logData = { "message": "sample log entry for python-ut-device","severity": 0,"data": "Diagnostic log entry","timestamp": "2016-05-16T08:44:23.909Z"}
             apiClient.addDiagnosticLog(self.deviceType,"device-not-exists",logData)
-        assert_equal(e.exception.msg, 'Device not found') 
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Device not found')
+
+    @raises(Exception)
     def testAddDiagnosticLog500UnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             logData = { "message": "sample log entry for python-ut-device","severity": 0,"data": "Diagnostic log entry","timestamp": "2016-05-16T08:44:23.909Z"}
             apiClient.addDiagnosticLog("device-not-exists",self.deviceType,logData)
-        assert_equal(e.exception.msg, '[500] Unexpected error') 
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, '[500] Unexpected error')
+
+    @raises(Exception)
     def testAddDiagnosticLogUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             logData = { "message": "sample log entry for python-ut-device","severity": 0,"data": "Diagnostic log entry","timestamp": "2016-05-16T08:44:23.909Z"}
             apiClient.addDiagnosticLog({"typeId":self.deviceType},{"deviceId":self.deviceId},logData)
-        assert_equal(e.exception.msg, 'Unexpected error')          
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Unexpected error')
+
+    @raises(Exception)
     def testAddDiagnosticLogInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             logData = { "message": "sample log entry for python-ut-device","severity": 0,"data": "Diagnostic log entry","timestamp": "2016-05-16T08:44:23.909Z"}
             apiClient.addDiagnosticLog(self.deviceType, self.deviceId,logData)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
+
     def testDeviceDiagnosticsErrorCodes(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
         errorData = { "errorCode": 0,"timestamp": "2016-05-17T07:16:42.312Z"}
-    
+
         #Clear all error codes for the device
         assert_true(apiClient.clearAllErrorCodes(self.deviceType, self.deviceId))
-            
+
         #Add one error code
         assert_true(apiClient.addErrorCode(self.deviceType, self.deviceId, errorData))
-          
+
         #Get all error codes
         assert_equal(apiClient.getAllDiagnosticErrorCodes(self.deviceType, self.deviceId)[0]['errorCode'],errorData['errorCode'])
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testAddErrorCodeInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             errorData = { "errorCode": 0,"timestamp": "2016-05-17T07:16:42.312Z"}
             apiClient.addErrorCode(self.deviceType, self.deviceId, errorData)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-            
-    @raises(Exception)    
+
+    @raises(Exception)
     def testAddErrorCode500UnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.addErrorCode(self.deviceType,self.deviceId,None)
-        assert_equal(e.exception.msg, '[500] Unexpected error') 
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, '[500] Unexpected error')
+
+    @raises(Exception)
     def testAddErrorCodeUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             errorData = { "errorCode": "","timestamp": "2016-05-17T07:16:42.312Z"}
             apiClient.addErrorCode(self.deviceType,self.deviceId,errorData)
         assert_equal(e.exception.msg, 'Unexpected error')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testAddErrorCodeNotFound(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             errorData = { "errorCode": 0,"timestamp": "2016-05-17T07:16:42.312Z"}
             apiClient.addErrorCode(self.deviceType,None,errorData)
-        assert_equal(e.exception.msg, 'Error Code not found')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Error Code not found')
+
+    @raises(Exception)
     def testGetAllDiagnosticErrorCodesInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getAllDiagnosticErrorCodes(self.deviceType, self.deviceId)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-            
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetAllDiagnosticErrorCodes500UnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getAllDiagnosticErrorCodes(None,None)
-        assert_equal(e.exception.msg, '[500] Unexpected error')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, '[500] Unexpected error')
+
+    @raises(Exception)
     def testGetAllDiagnosticErrorCodesUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getAllDiagnosticErrorCodes({"typeId":self.deviceType},self.deviceId)
         assert_equal(e.exception.msg, 'Unexpected error')
-            
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetAllDiagnosticErrorCodesNotFound(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getAllDiagnosticErrorCodes(self.deviceType,None)
-        assert_equal(e.exception.msg, 'Error Code not found')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Error Code not found')
+
+    @raises(Exception)
     def testClearAllErrorCodesInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.clearAllErrorCodes(self.deviceType, self.deviceId)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-            
-    @raises(Exception)    
+
+    @raises(Exception)
     def testClearAllErrorCodesUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.clearAllErrorCodes({"typeId":self.deviceType},self.deviceId)
         assert_equal(e.exception.msg, 'Unexpected error')
-            
-    @raises(Exception)    
+
+    @raises(Exception)
     def testClearAllErrorCodesNotFound(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.clearAllErrorCodes(self.deviceType,None)
         assert_equal(e.exception.msg, 'Error Code not found')
-        
+
     def testGetHistoricalEvents(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        
+
         #Call getHistoricalEvents with both - deviceType and device
         apiClient.getHistoricalEvents(typeId=self.deviceType, deviceId=self.deviceId)
-        
+
         #Call getHistoricalEvents only with both - deviceType
         apiClient.getHistoricalEvents(typeId=self.deviceType)
-        
+
         #Call getHistoricalEvents with no parameters
-        apiClient.getHistoricalEvents()                
-        
-    def testGetServiceStatus(self):    
+        apiClient.getHistoricalEvents()
+
+    def testGetServiceStatus(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        
+
         statusData = apiClient.getServiceStatus()
-        
+
         #assert_equal(statusData['us']['messaging'],'green')
         #assert_equal(statusData['us']['historian'],'green')
         #assert_equal(statusData['us']['dashboard'],'green')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetServiceStatusUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getServiceStatus()
-        assert_equal(e.exception.msg, 'Unexpected Error')    
-    
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Unexpected Error')
+
+    @raises(Exception)
     def testGetActiveDevicesBadRequest(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getActiveDevices({"dummy":"value"})
         assert_equal(e.exception.msg, 'Bad Request')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetActiveDevicesUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getActiveDevices({'start':'2015','end':'2016'})
-        assert_equal(e.exception.msg, 'Unexpected Error')        
-        
-    @SkipTest    
+        assert_equal(e.exception.msg, 'Unexpected Error')
+
+    @SkipTest
     def testGetActiveDevices(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        apiClient.getActiveDevices({'start':'2015-01-01','end':'2016-01-01'})    
-        
+        apiClient.getActiveDevices({'start':'2015-01-01','end':'2016-01-01'})
+
     def testGetDataTraffic(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        apiClient.getDataTraffic({'start':'2016-01-01','end':'2016-05-01'})    
-        
-    @raises(Exception)    
+        apiClient.getDataTraffic({'start':'2016-01-01','end':'2016-05-01'})
+
+    @raises(Exception)
     def testGetDataTrafficBadRequest(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDataTraffic({'start':'2017-01-01','end':'2016-05-01'})
-        assert_equal(e.exception.msg, 'Bad Request')    
-    
-    @SkipTest    
+        assert_equal(e.exception.msg, 'Bad Request')
+
+    @SkipTest
     def testGetHistoricalDataUsage(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        apiClient.getHistoricalDataUsage({'start':'2016-01-01','end':'2016-05-01'})    
-        
-    @raises(Exception)    
+        apiClient.getHistoricalDataUsage({'start':'2016-01-01','end':'2016-05-01'})
+
+    @raises(Exception)
     def testGetHistoricalDataUsageBadRequest(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getHistoricalDataUsage({'start':'2017-01-01','end':'2016-05-01'})
-        assert_equal(e.exception.msg, 'Bad Request')    
+        assert_equal(e.exception.msg, 'Bad Request')
 
     def testDeviceManagementAPIs(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
-        mgmtRequest = {"action": "device/reboot", "parameters": [{"name": "action","value": "reboot" }], 
+        mgmtRequest = {"action": "device/reboot", "parameters": [{"name": "action","value": "reboot" }],
                        "devices": [{ "typeId": self.deviceType, "deviceId": self.deviceId }]}
-        
+
         #Instantiate required device managed client
         deviceConfFile="device.conf"
         deviceOptions = ibmiotf.device.ParseConfigFile(deviceConfFile)
         deviceInfoObj = ibmiotf.device.DeviceInfo()
         managedClient = ibmiotf.device.ManagedClient(deviceOptions,deviceInfo=deviceInfoObj)
         managedClient.connect()
-                
+
         #Initialize device management request
         initResult = apiClient.initiateDeviceManagementRequest(mgmtRequest)
         reqId = initResult['reqId']
-        
+
         #Get device management request using request id
         getResult = apiClient.getDeviceManagementRequest(reqId)
         assert_true(getResult['action'],mgmtRequest['action'])
-        
+
         #Get device management request status using request id
         getStatusResult = apiClient.getDeviceManagementRequestStatus(reqId)
         results = getStatusResult['results']
         assert_true(results[0]['typeId'],self.deviceType)
         assert_true(results[0]['deviceId'],self.deviceId)
-        
+
         #Get device management request status using typeId and deviceId
         getStatusResult = apiClient.getDeviceManagementRequestStatusByDevice(reqId,self.deviceType,self.deviceId)
         assert_true(getStatusResult['status'] == 1)
         assert_false(getStatusResult['complete'])
-        
+
         #Get all management requests
         getResult = apiClient.getAllDeviceManagementRequests()
         results = getResult['results']
         assert_true(results[0]['action'],mgmtRequest['action'])
-        
+
         #Delete initiated device management request
         assert_true(apiClient.deleteDeviceManagementRequest(reqId))
-        
+
         #Disconnect managed client
         managedClient.disconnect()
-            
-    @raises(Exception)    
+
+    @raises(Exception)
     def testInitiateDeviceManagementRequestUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.initiateDeviceManagementRequest({'typeId':'Python'})
-        assert_equal(e.exception.msg, 'Unexpected Error')        
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Unexpected Error')
+
+    @raises(Exception)
     def testInitiateDeviceManagementRequest500UnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.initiateDeviceManagementRequest(None)
-        assert_equal(e.exception.msg, '500 Unexpected Error')    
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, '500 Unexpected Error')
+
+    @raises(Exception)
     def testDeleteDeviceManagementRequestUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.deleteDeviceManagementRequest({'typeId':'Python'})
         assert_equal(e.exception.msg, 'Unexpected Error')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testDeleteDeviceManagementRequestBadRequestID(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.deleteDeviceManagementRequest('not-exists')
-        assert_equal(e.exception.msg, 'Request Id not found')        
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Request Id not found')
+
+    @raises(Exception)
     def testDeleteDeviceManagementRequestInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.deleteDeviceManagementRequest('requestId')
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceManagementRequestUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceManagementRequest({'typeId':'Python'})
         assert_equal(e.exception.msg, 'Unexpected Error')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceManagementRequestBadRequestID(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceManagementRequest('not-exists')
-        assert_equal(e.exception.msg, 'Request Id not found')        
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Request Id not found')
+
+    @raises(Exception)
     def testGetDeviceManagementRequestInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getDeviceManagementRequest('requestId')
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceManagementRequestStatusUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceManagementRequestStatus({'typeId':'Python'})
         assert_equal(e.exception.msg, 'Unexpected Error')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceManagementRequestStatusBadRequestID(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceManagementRequestStatus('not-exists')
-        assert_equal(e.exception.msg, 'Request Id not found')        
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Request Id not found')
+
+    @raises(Exception)
     def testGetDeviceManagementRequestStatusInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getDeviceManagementRequestStatus('requestId')
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceManagementRequestStatusByDeviceInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getDeviceManagementRequestStatusByDevice('requestId',self.deviceType,self.deviceId)
         assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
-        
-    @raises(Exception)    
+
+    @raises(Exception)
     def testGetDeviceManagementRequestStatusByDeviceBadRequestID(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceManagementRequestStatusByDevice('id-not-exists',self.deviceType,self.deviceId)
-        assert_equal(e.exception.msg, 'Request status not found')  
-        
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'Request status not found')
+
+    @raises(Exception)
     def testGetDeviceManagementRequestStatusByDeviceUnexpectedError(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDeviceManagementRequestStatusByDevice({'reqId':'req-id'},self.deviceType,self.deviceId)
-        assert_equal(e.exception.msg, 'Unexpected Error')  
-       
+        assert_equal(e.exception.msg, 'Unexpected Error')
+
     def testGatewayAPISupport(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
         gwTypeId = "add-gw-device-type-test"
         devId = "reg-dev-undr-gw-test"
-        
+
         #Add new gateway device type
         addResult = apiClient.addGatewayDeviceType(gwTypeId)
         assert_equal(addResult['id'],gwTypeId)
-        
-        #Get devices under above added gateway device type                    
+
+        #Get devices under above added gateway device type
         getResult = apiClient.getDevicesConnectedThroughGateway(gwTypeId)
         assert_equal(getResult['results'],[])
-        
+
         #Add new device through above added gateway
         addResult = apiClient.registerDeviceUnderGateway(gwTypeId,devId)
         assert_equal(addResult['typeId'],gwTypeId)
         assert_equal(addResult['deviceId'],devId)
-        
-        #Get devices under above added gateway device type                    
+
+        #Get devices under above added gateway device type
         getResult = apiClient.getDevicesConnectedThroughGateway(gwTypeId)
         assert_equal(getResult['results'][0]['typeId'],gwTypeId)
         assert_equal(getResult['results'][0]['deviceId'],devId)
-        
+
         getResult = apiClient.getDevicesConnectedThroughGateway(gwTypeId,devId)
         assert_equal(getResult['typeId'],gwTypeId)
         assert_equal(getResult['deviceId'],devId)
-        
+
         #Remove the added device followed by the removal of gateway device type
         assert_true(apiClient.deleteDevice(gwTypeId, devId))
         assert_true(apiClient.deleteDeviceType(gwTypeId))
-                    
-    @raises(Exception)    
+
+    @raises(Exception)
     def testgetDevicesConnectedThroughGatewayInvalidAuthKey(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.invalidAuthKey},self.logger)
             apiClient.getDevicesConnectedThroughGateway(self.gatewayType)
-        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')                
+        assert_equal(e.exception.msg, 'The authentication method is invalid or the api key used does not exist')
 
-    @raises(Exception)    
+    @raises(Exception)
     def testgetDevicesConnectedThroughGatewayAuthTokenEmpty(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken[0:-1], "auth-key": self.authKey},self.logger)
             apiClient.getDevicesConnectedThroughGateway(self.gatewayType)
-        assert_equal(e.exception.msg, 'The authentication token is empty or invalid')                
- 
-    @raises(Exception)    
+        assert_equal(e.exception.msg, 'The authentication token is empty or invalid')
+
+    @raises(Exception)
     def testgetDevicesConnectedThroughGatewayNotExistingDevice(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken, "auth-key": self.authKey},self.logger)
             apiClient.getDevicesConnectedThroughGateway(self.gatewayType,"device-not-exists")
         assert_equal(e.exception.msg, 'The device does not exist')
+
+    def testDeviceManagementExtensionMethods(self):
+        def doDMEAction(topic,data,reqId):
+            print("In DME Action Callabck")
+            print("Received topic = "+topic)
+            print("Received reqId = "+reqId)
+            print("Received data = %s" %data)
+            return True
+
+        apiClient = ibmiotf.api.ApiClient({"auth-method": "token",
+           "auth-token": self.authToken, "auth-key": self.authKey},self.logger)
+
+        #Instantiate required device managed client
+        deviceConfFile="device.conf"
+        deviceOptions = ibmiotf.device.ParseConfigFile(deviceConfFile)
+        deviceInfoObj = ibmiotf.device.DeviceInfo()
+        managedClient = ibmiotf.device.ManagedClient(deviceOptions,deviceInfo=deviceInfoObj)
+        managedClient.connect()
+        managedClient.unmanage()
+
+        dmeData = {"bundleId": "example-dme-actions-v1",
+                   "displayName": {"en_US": "example-dme Actions v1"},
+                   "version": "1.0","actions": {"installPlugin": {
+                   "actionDisplayName": { "en_US": "Install Plug-in"},
+                   "parameters": [ { "name": "pluginURI",
+                                     "value": "http://example.dme.com",
+                                    "required": "true" } ] } } }
+        addResult = apiClient.createDeviceManagementExtensionPkg(dmeData)
+        assert_equal(addResult['bundleId'],'example-dme-actions-v1')
+
+        managedClient.dmeActionCallback = doDMEAction;
+        managedClient.manage(lifetime=0,supportDeviceMgmtExtActions=True,bundleId='example-dme-actions-v1')
+        mgmtRequest = {"action": "example-dme-actions-v1/installPlugin",
+                       "parameters": [{ "name": "pluginURI",
+                                         "value": "http://example.dme.com",}],
+                       "devices": [{ "typeId": self.deviceType, "deviceId": self.deviceId }]}
+        initResult = apiClient.initiateDeviceManagementRequest(mgmtRequest)
+        reqId = initResult['reqId']
+
+        getResult = apiClient.getAllDeviceManagementExtensionPkgs();
+        assert_equal(getResult['results'][0]['bundleId'],'edgeanalytics')
+
+
+        getResult = apiClient.getDeviceManagementExtensionPkg('example-dme-actions-v1')
+        assert_equal(getResult['bundleId'],'example-dme-actions-v1')
+
+        updData = {"displayName": {"en_US": "example-dme Actions v1"},
+                   "version": "1.1","actions": {"installPlugin": {
+                   "actionDisplayName": { "en_US": "Install Plug-in"},
+                   "parameters": [ { "name": "pluginURI",
+                                     "value": "http://example.dme.com",
+                                    "required": "true" } ] } } }
+        updResult = apiClient.updateDeviceManagementExtensionPkg('example-dme-actions-v1',updData)
+        assert_equal(updResult['bundleId'],'example-dme-actions-v1')
+        assert_equal(updResult['version'],'1.1')
+
+        assert_true(apiClient.deleteDeviceManagementExtensionPkg('example-dme-actions-v1'))
+        assert_true(apiClient.deleteDeviceManagementRequest(reqId))
+
+        managedClient.unmanage()
+        managedClient.disconnect()
+
+    @raises(Exception)
+    def testgetAllDeviceManagementExtensionPkgsException(self):
+        with assert_raises(APIException) as e:
+            apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken,
+                                               "auth-key": self.invalidAuthKey},self.logger)
+            apiClient.getAllDeviceManagementExtensionPkgs()
+        assert_equal(e.exception.msg, 'HTTP Error in getAllDeviceManagementExtensionPkgs')
+
+    @raises(Exception)
+    def testcreateDeviceManagementExtensionPkg(self):
+        with assert_raises(APIException) as e:
+            apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken,
+                                               "auth-key": self.invalidAuthKey},self.logger)
+            apiClient.createDeviceManagementExtensionPkg(None)
+        assert_equal(e.exception.msg, 'HTTP Error in createDeviceManagementExtensionPkg')
+
+    @raises(Exception)
+    def testdeleteDeviceManagementExtensionPkg(self):
+        with assert_raises(APIException) as e:
+            apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken,
+                                               "auth-key": self.invalidAuthKey},self.logger)
+            apiClient.deleteDeviceManagementExtensionPkg(None)
+        assert_equal(e.exception.msg, 'HTTP Error in deleteDeviceManagementExtensionPkg')
+
+    @raises(Exception)
+    def testgetDeviceManagementExtensionPkg(self):
+        with assert_raises(APIException) as e:
+            apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken,
+                                               "auth-key": self.invalidAuthKey},self.logger)
+            apiClient.getDeviceManagementExtensionPkg(None)
+        assert_equal(e.exception.msg, 'HTTP Error in getDeviceManagementExtensionPkg')
+
+    @raises(Exception)
+    def testupdateDeviceManagementExtensionPkg(self):
+        with assert_raises(APIException) as e:
+            apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken,
+                                               "auth-key": self.invalidAuthKey},self.logger)
+            apiClient.updateDeviceManagementExtensionPkg(None,None)
+        assert_equal(e.exception.msg, 'HTTP Error in updateDeviceManagementExtensionPkg')

--- a/test/deviceTest.py
+++ b/test/deviceTest.py
@@ -4,7 +4,7 @@
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html 
+# http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
 #   Lokesh Haralakatta  - Initial Contribution
@@ -21,7 +21,7 @@ class TestDevice:
     deviceClient=None
     managedClient=None
     options=None
-    
+
     @classmethod
     def setup_class(self):
         deviceFile="device.conf"
@@ -30,25 +30,25 @@ class TestDevice:
         self.deviceType = self.options['type']
         self.deviceId = self.options['id']
         self.authToken = self.options['auth-token']
-        
-        self.deviceClient = ibmiotf.device.Client(self.options)    
-                
+
+        self.deviceClient = ibmiotf.device.Client(self.options)
+
         #Create default DeviceInfo Instance and associate with ManagedClient Instance
         deviceInfoObj = ibmiotf.device.DeviceInfo()
         deviceInfoObj.fwVersion = 0.0
         self.managedClient = ibmiotf.device.ManagedClient(self.options,deviceInfo=deviceInfoObj)
-        
+
         #Get application options
         appConfFile="application.conf"
         self.appOptions = ibmiotf.application.ParseConfigFile(appConfFile)
-        
+
         #Setup logger instance
-        self.logger = logging.getLogger(self.__module__+"."+self.__class__.__name__)
+        self.logger = logging.getLogger(self.__module__+".deviceTest")
         self.logger.setLevel(logging.INFO)
-    
+
         self.apiClient = ibmiotf.api.ApiClient(self.appOptions,self.logger)
-        
-    @classmethod    
+
+    @classmethod
     def teardown_class(self):
         self.deviceClient=None
         self.managedClient=None
@@ -59,51 +59,51 @@ class TestDevice:
         with assert_raises(ConfigurationException) as e:
             ibmiotf.device.Client({})
         assert_equal(e.exception.msg, 'Missing required property: org')
-        
+
     @raises(Exception)
     def testMissingOrg(self):
         with assert_raises(ConfigurationException) as e:
-            ibmiotf.device.Client({"org": None, "type": self.deviceType, "id": self.deviceId, 
+            ibmiotf.device.Client({"org": None, "type": self.deviceType, "id": self.deviceId,
                                    "auth-method": "token", "auth-token": self.authToken })
         assert_equal(e.exception.msg, 'Missing required property: org')
 
     @raises(Exception)
     def testMissingType(self):
         with assert_raises(ConfigurationException) as e:
-            ibmiotf.device.Client({"org": self.org, "type": None, "id": self.deviceId, 
+            ibmiotf.device.Client({"org": self.org, "type": None, "id": self.deviceId,
                                    "auth-method": "token", "auth-token": self.authToken })
         assert_equal(e.exception.msg, 'Missing required property: type')
 
     @raises(Exception)
     def testMissingId(self):
         with assert_raises(ConfigurationException) as e:
-            ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": None, 
+            ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": None,
                                    "auth-method": "token", "auth-token": self.authToken})
         assert_equal(e.exception.msg, 'Missing required property: id')
 
     @raises(Exception)
     def testMissingAuthMethod(self):
         with assert_raises(ConfigurationException) as e:
-            ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId, 
+            ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId,
                                    "auth-method": None, "auth-token": self.authToken})
         assert_equal(e.exception.msg, 'Missing required property: auth-method')
 
     @raises(Exception)
     def testMissingAuthToken(self):
         with assert_raises(ConfigurationException) as e:
-            ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId, 
+            ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId,
                                    "auth-method": "token", "auth-token": None })
         assert_equal(e.exception.msg, 'Missing required property: auth-token')
-        
+
     @raises(Exception)
     def testUnSupportedAuthMethod(self):
         with assert_raises(UnsupportedAuthenticationMethod) as e:
-            ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId, 
+            ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId,
                                    "auth-method": "unsupported-method", "auth-token": self.authToken})
         assert_equal(e.exception_type,UnsupportedAuthenticationMethod)
-        
+
     def testDeviceClientInstance(self):
-        deviceCli = ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId, 
+        deviceCli = ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId,
                                            "auth-method": "token", "auth-token": self.authToken})
         assert_is_instance(deviceCli , ibmiotf.device.Client)
 
@@ -113,46 +113,46 @@ class TestDevice:
         with assert_raises(ConfigurationException) as e:
             ibmiotf.device.ParseConfigFile(deviceFile)
         assert_equal(e.exception.msg, 'Error reading device configuration file')
-        
+
     @raises(Exception)
-    def testInvalidConfigFile(self):    
+    def testInvalidConfigFile(self):
         deviceFile="nullValues.conf"
         with assert_raises(AttributeError) as e:
             ibmiotf.device.ParseConfigFile(deviceFile)
         assert_equal(e.exception, AttributeError)
-        
-    @SkipTest    
+
+    @SkipTest
     def testNotAuthorizedConnect(self):
-        client = ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId, 
+        client = ibmiotf.device.Client({"org": self.org, "type": self.deviceType, "id": self.deviceId,
                                               "auth-method": "token", "auth-token": "MGhUixxxxxxxxxxxx", "auth-key":"a-xxxxxx-s1tsofmoxo"})
         with assert_raises(ConnectionException) as e:
             client.connect()
         assert_equals(e.exception, ConnectionException)
         assert_equals(e.exception.msg,'Not authorized')
-        
+
     @SkipTest
     def testMissingMessageEncoder(self):
         with assert_raises(MissingMessageEncoderException)as e:
             myData={'name' : 'foo', 'cpu' : 60, 'mem' : 50}
             self.deviceClient.connect()
             self.deviceClient.publishEvent("missingMsgEncode", "jason", myData)
-        assert_equals(e.exception, MissingMessageEncoderException)    
-       
+        assert_equals(e.exception, MissingMessageEncoderException)
+
     def testPublishEvent(self):
         def devPublishCallback():
             print("Device Publish Event done!!!")
-            
+
         myData={'name' : 'foo', 'cpu' : 60, 'mem' : 50}
         self.deviceClient.connect()
         assert_true(self.deviceClient.publishEvent("testPublishEvent", "json", myData,on_publish=devPublishCallback,qos=2))
-        self.deviceClient.disconnect()   
-                
+        self.deviceClient.disconnect()
+
     def testPublishEventOverHTTPs(self):
         myData={'name' : 'foo', 'cpu' : 60, 'mem' : 50}
         self.deviceClient.connect()
         assert_equals(self.deviceClient.publishEventOverHTTP("testPublishEventHTTPs", myData),200)
-        self.deviceClient.disconnect()   
-                                        
+        self.deviceClient.disconnect()
+
     def testPublishEventOverHTTP(self):
         client = ibmiotf.device.Client({"org": "quickstart", "type": self.deviceType, "id": self.deviceId,
                                         "auth-method":"None", "auth-token":"None" })
@@ -160,39 +160,39 @@ class TestDevice:
         myData={'name' : 'foo', 'cpu' : 60, 'mem' : 50}
         assert_equals(client.publishEventOverHTTP("testPublishEventHTTP", myData),200)
         client.disconnect()
-        
+
     def testDeviceInfoInstance(self):
         deviceInfoObj = ibmiotf.device.DeviceInfo()
         assert_is_instance(deviceInfoObj, ibmiotf.device.DeviceInfo)
-        print(deviceInfoObj)     
-    
+        print(deviceInfoObj)
+
     def testDeviceFirmwareInstance(self):
         deviceFWObj = ibmiotf.device.DeviceFirmware()
         assert_is_instance(deviceFWObj, ibmiotf.device.DeviceFirmware)
         print(deviceFWObj)
-        
+
     def testManagedClientInstance(self):
         managedClient = ibmiotf.device.ManagedClient(self.options)
-        assert_is_instance(managedClient, ibmiotf.device.ManagedClient)    
-        
+        assert_is_instance(managedClient, ibmiotf.device.ManagedClient)
+
     @raises(Exception)
     def testManagedClientQSException(self):
         with assert_raises(Exception)as e:
             options={"org": "quickstart", "type": self.deviceType, "id": self.deviceId,
                                         "auth-method":"None", "auth-token":"None" }
             ibmiotf.device.ManagedClient(options)
-        assert_equals(e.exception, Exception)    
-    
+        assert_equals(e.exception, Exception)
+
     def testManagedClientSetMethods(self):
         self.managedClient.connect()
         #Define device properties to be notified whenever reset
-        self.managedClient._deviceMgmtObservations = ["deviceInfo.manufacturer", "deviceInfo.descriptiveLocation", 
-                                                "deviceInfo.fwVersion", "deviceInfo.model", "deviceInfo.description", 
+        self.managedClient._deviceMgmtObservations = ["deviceInfo.manufacturer", "deviceInfo.descriptiveLocation",
+                                                "deviceInfo.fwVersion", "deviceInfo.model", "deviceInfo.description",
                                                 "deviceInfo.deviceClass", "deviceInfo.hwVersion", "deviceInfo.serialNumber"]
-        
+
         #Reset managedClient properties  and validate the returned is instance of threading.Event
         assert_is_instance(self.managedClient.setErrorCode(1),threading.Event)
-        assert_is_instance(self.managedClient.setLocation(longitude=200, latitude=278),threading.Event)   
+        assert_is_instance(self.managedClient.setLocation(longitude=200, latitude=278),threading.Event)
         assert_is_instance(self.managedClient.setSerialNumber('iot-device-12345'),threading.Event)
         assert_is_instance(self.managedClient.setManufacturer("IBM India Pvt Ltd"),threading.Event)
         assert_is_instance(self.managedClient.setModel("2016"),threading.Event)
@@ -201,174 +201,207 @@ class TestDevice:
         assert_is_instance(self.managedClient.setFwVersion("1.0"),threading.Event)
         assert_is_instance(self.managedClient.setHwVersion("2.0"),threading.Event)
         assert_is_instance(self.managedClient.setDescriptiveLocation("ISL Lab Bangalore"),threading.Event)
-        assert_is_instance(self.managedClient.clearErrorCodes(),threading.Event)       
+        assert_is_instance(self.managedClient.clearErrorCodes(),threading.Event)
         assert_is_instance(self.managedClient.addLog(),threading.Event)
         assert_is_instance(self.managedClient.clearLog(),threading.Event)
         assert_is_instance(self.managedClient.unmanage(),threading.Event)
-        
+
         self.managedClient.disconnect()
-        
+
     def testPublishCommandByApplication(self):
         def devCmdCallback(cmd):
             assert_true(cmd.data['rebootDelay'] == 50)
-  
+
         def appCmdPublishCallback():
             print("Application Publish Command done!!!")
-  
+
         self.deviceClient.commandCallback = devCmdCallback;
         self.deviceClient.connect()
-        
-        appClient = ibmiotf.application.Client(self.appOptions)        
+
+        appClient = ibmiotf.application.Client(self.appOptions)
         appClient.connect()
         commandData={'rebootDelay' : 50}
         assert_true(appClient.publishCommand(self.deviceType, self.deviceId, "reboot", "json", commandData, on_publish=appCmdPublishCallback))
-        time.sleep(1)   
-        
+        time.sleep(1)
+
         appClient.disconnect()
         self.deviceClient.disconnect()
 
     def testDeviceRebootAction(self):
         def rebootActionCB(reqId,action):
             print("Device rebootActionCB called")
-                        
-        mgmtRequest = {"action": "device/reboot", "parameters": [{"name": "action","value": "reboot" }], 
+
+        mgmtRequest = {"action": "device/reboot", "parameters": [{"name": "action","value": "reboot" }],
                        "devices": [{ "typeId": self.deviceType, "deviceId": self.deviceId }]}
-        
+
         #Setup user defined reboot call back
         self.managedClient.deviceActionCallback = rebootActionCB
         self.managedClient.connect()
-        
-        
+
+
         #Initialize device management request to reboot
         initResult = self.apiClient.initiateDeviceManagementRequest(mgmtRequest)
         reqId = initResult['reqId']
-        
+
         time.sleep(1)
-        
+
         #Delete initiated device management request
         assert_true(self.apiClient.deleteDeviceManagementRequest(reqId))
-        
+
         self.managedClient.disconnect()
-    
+
     def testDeviceFactoryResetAction(self):
         def factoryResetActionCB(reqId,action):
             print("Device factoryResetActionCB called")
-         
-        mgmtRequest = {"action": "device/factoryReset", "parameters": [{"name": "action","value": "reset" }], 
+
+        mgmtRequest = {"action": "device/factoryReset", "parameters": [{"name": "action","value": "reset" }],
                        "devices": [{ "typeId": self.deviceType, "deviceId": self.deviceId }]}
-        
+
         #Setup user defined factory reset call back
         self.managedClient.deviceActionCallback = factoryResetActionCB
         self.managedClient.connect()
-                
+
         #Initialize device management request for factory reset
         initResult = self.apiClient.initiateDeviceManagementRequest(mgmtRequest)
         reqId = initResult['reqId']
-        
+
         time.sleep(1)
-        
+
         #Delete initiated device management request
         assert_true(self.apiClient.deleteDeviceManagementRequest(reqId))
-        
+
         self.managedClient.disconnect()
-    
+
     def testFirmwareDownloadAction(self):
         def downloadHandler(client,info):
             try:
-                print("Setting ManagedClient.UPDATESTATE_DOWNLOADING") 
+                print("Setting ManagedClient.UPDATESTATE_DOWNLOADING")
                 client.setState(device.ManagedClient.UPDATESTATE_DOWNLOADING)
                 print("Setting ManagedClient.UPDATESTATE_DOWNLOADED")
                 client.setState(device.ManagedClient.UPDATESTATE_DOWNLOADED)
             except Exception :
                 print("Exception from downloadHandler")
-                    
+
         def firmwareDownloadActionCB(action,devInfo):
             print("Device firmwareDownloadActionCB called")
             self.managedClient.setState(device.ManagedClient.UPDATESTATE_IDLE)
             print("Calling downloadHandler Thread")
-            
+
             dThread = threading.Thread(target=downloadHandler,args=(self.managedClient,devInfo))
             dThread.start()
             dThread.join()
             print("downloadHandler Thread is done")
-                        
-            
+
+
         mgmtRequest = {"action": "firmware/download", "parameters": [{"name": "version", "value": "0.1.11" },
                        {"name": "name", "value": "RasPi01 firmware"}, {"name": "verifier", "value": "123df"},
                        {"name": "uri","value": "https://github.com/ibm-messaging/iot-raspberrypi/releases/download/1.0.2.1/iot_1.0-2_armhf.deb"}],
                        "devices": [{"typeId": self.deviceType,"deviceId": self.deviceId}]};
-                       
+
         self.managedClient.__firmwareUpdate = device.DeviceFirmware('0.0','0.0','uri','verifier',device.ManagedClient.UPDATESTATE_IDLE,
                                                       device.ManagedClient.UPDATESTATE_IDLE,'updatedDateTime')
-                
+
         #Setup user defined firmware download call back
         self.managedClient.firmwereActionCallback = firmwareDownloadActionCB
         self.managedClient.connect()
         self.managedClient.setState(device.ManagedClient.UPDATESTATE_IDLE)
         self.managedClient.setUpdateStatus(device.ManagedClient.UPDATESTATE_IDLE)
-                        
+
         #Initialize device management request for firmware download
         initResult = self.apiClient.initiateDeviceManagementRequest(mgmtRequest)
         reqId = initResult['reqId']
         time.sleep(1)
-        
+
         #Delete initiated device management request
         assert_true(self.apiClient.deleteDeviceManagementRequest(reqId))
-      
+
         self.managedClient.disconnect()
-    
-    @SkipTest    
+
+    @SkipTest
     def testFirmwareUpdateAction(self):
         def updateHandler(client,info):
             try:
-                print("Setting ManagedClient.UPDATESTATE_IN_PROGRESS") 
+                print("Setting ManagedClient.UPDATESTATE_IN_PROGRESS")
                 client.setUpdateStatus(device.ManagedClient.UPDATESTATE_IN_PROGRESS)
                 print("Setting ManagedClient.UPDATESTATE_SUCCESS")
                 threading.Timer(5,client.setUpdateStatus,[device.ManagedClient.UPDATESTATE_SUCCESS]).start()
-                
+
             except Exception :
                 print("Exception from updateHandler")
-                    
+
         def firmwareUpdateActionCB(action,devInfo):
             print("Device firmwareUpdateActionCB called")
             self.managedClient.setUpdateStatus(device.ManagedClient.UPDATESTATE_IDLE)
             print("Calling updateHandler Thread")
-            
+
             uThread = threading.Thread(target=updateHandler,args=(self.managedClient,devInfo))
             uThread.start()
             uThread.join()
             print("updateHandler Thread is done")
-                        
-            
+
+
         mgmtRequest = {"action": "firmware/update", "parameters": [{"name": "version", "value": "0.1.11" },
                        {"name": "name", "value": "RasPi01 firmware"}, {"name": "verifier", "value": "123df"},
                        {"name": "uri","value": "https://github.com/ibm-messaging/iot-raspberrypi/releases/download/1.0.2.1/iot_1.0-2_armhf.deb"}],
                        "devices": [{"typeId": self.deviceType,"deviceId": self.deviceId}]};
-                       
+
         self.managedClient.__firmwareUpdate = device.DeviceFirmware('0.0','0.0','uri','verifier',device.ManagedClient.UPDATESTATE_IDLE,
                                                       device.ManagedClient.UPDATESTATE_IDLE,'updatedDateTime')
-                
+
         #Setup user defined firmware download call back
         self.managedClient.firmwereActionCallback = firmwareUpdateActionCB
         self.managedClient.connect()
         self.managedClient.setUpdateStatus(device.ManagedClient.UPDATESTATE_IDLE)
-                        
+
         #Initialize device management request for firmware download
         initResult = self.apiClient.initiateDeviceManagementRequest(mgmtRequest)
         reqId = initResult['reqId']
         time.sleep(1)
-        
+
         #Delete initiated device management request
         assert_true(self.apiClient.deleteDeviceManagementRequest(reqId))
-      
-        self.managedClient.disconnect()        
-     
+
+        self.managedClient.disconnect()
+
     def testKeepAliveIntervalMethods(self):
         assert_equals(self.deviceClient.getKeepAliveInterval(),60)
         self.deviceClient.setKeepAliveInterval(120)
         self.deviceClient.connect()
         assert_equals(self.deviceClient.getKeepAliveInterval(),120)
         self.deviceClient.disconnect()
-        
-    
- 
+
+    def testDMEAction(self):
+        def doDMEAction(topic,data,reqId):
+            print("In DME Action Callabck")
+            print("Received topic = "+topic)
+            print("Received reqId = "+reqId)
+            print("Received data = %s" %data)
+            return True
+
+        self.managedClient.connect()
+        self.managedClient.unmanage()
+
+        dmeData = {"bundleId": "example-dme-actions-v1",
+                   "displayName": {"en_US": "example-dme Actions v1"},
+                   "version": "1.0","actions": {"installPlugin": {
+                   "actionDisplayName": { "en_US": "Install Plug-in"},
+                   "parameters": [ { "name": "pluginURI",
+                                     "value": "http://example.dme.com",
+                                    "required": "true" } ] } } }
+        addResult = self.apiClient.createDeviceManagementExtensionPkg(dmeData)
+        assert_equal(addResult['bundleId'],'example-dme-actions-v1')
+
+        self.managedClient.dmeActionCallback = doDMEAction;
+        self.managedClient.manage(lifetime=0,supportDeviceMgmtExtActions=True,bundleId='example-dme-actions-v1')
+        mgmtRequest = {"action": "example-dme-actions-v1/installPlugin",
+                       "parameters": [{ "name": "pluginURI",
+                                         "value": "http://example.dme.com",}],
+                       "devices": [{ "typeId": self.deviceType, "deviceId": self.deviceId }]}
+        initResult = self.apiClient.initiateDeviceManagementRequest(mgmtRequest)
+        reqId = initResult['reqId']
+
+        assert_true(self.apiClient.deleteDeviceManagementExtensionPkg('example-dme-actions-v1'))
+        assert_true(self.apiClient.deleteDeviceManagementRequest(reqId))
+
+        self.managedClient.unmanage()
+        self.managedClient.disconnect()


### PR DESCRIPTION
The changes include following - 

- Code changes to add DME support to device.py and api.py
- Required unit tests added to deviceTest.py and apiTest.py
- Added required documentation changes
- Added sample program under samples/managedDevice
- Executed the complete unit test suite with all the changes to make sure the existing functionality is not regressed. Here is the link to jenkins build - http://9.124.102.159:8080/job/Watson-IoT-Python/152/