### PR TITLE
Fix logger parameter issue with ApiClient Class

### DIFF
--- a/src/ibmiotf/api.py
+++ b/src/ibmiotf/api.py
@@ -77,10 +77,14 @@ class ApiClient():
 	dmeRequests = 'https://%s/api/v0002/mgmt/custom/bundle'
 	dmeSingleRequest = 'https://%s/api/v0002/mgmt/custom/bundle/%s'
 
-	def __init__(self, options, logger):
+	def __init__(self, options, logger=None):
 		self.__options = options
 
 		# Configure logging
+		if logger is None:
+			logger = logging.getLogger(self.__module__+"."+self.__class__.__name__)
+			logger.setLevel(logging.INFO)
+
 		self.logger = logger
 
 		if 'auth-key' not in self.__options or self.__options['auth-key'] is None:

--- a/test/apiTest.py
+++ b/test/apiTest.py
@@ -1075,7 +1075,7 @@ class TestApi:
 
     def testDeviceManagementExtensionMethods(self):
         apiClient = ibmiotf.api.ApiClient({"auth-method": "token",
-           "auth-token": self.authToken, "auth-key": self.authKey},self.logger)
+           "auth-token": self.authToken, "auth-key": self.authKey})
 
         dmeData = {"bundleId": "example-dme-actions-v1",
                    "displayName": {"en_US": "example-dme Actions v1"},
@@ -1104,7 +1104,7 @@ class TestApi:
         assert_equal(updResult['version'],'1.1')
 
         assert_true(apiClient.deleteDeviceManagementExtensionPkg('example-dme-actions-v1'))
-        
+
     @raises(Exception)
     def testgetAllDeviceManagementExtensionPkgsException(self):
         with assert_raises(APIException) as e:
@@ -1141,6 +1141,6 @@ class TestApi:
     def testupdateDeviceManagementExtensionPkg(self):
         with assert_raises(APIException) as e:
             apiClient = ibmiotf.api.ApiClient({"auth-method": "token","auth-token": self.authToken,
-                                               "auth-key": self.invalidAuthKey},self.logger)
+                                               "auth-key": self.invalidAuthKey})
             apiClient.updateDeviceManagementExtensionPkg(None,None)
         assert_equal(e.exception.msg, 'HTTP Error in updateDeviceManagementExtensionPkg')


### PR DESCRIPTION
Tested the changes with the unit tests and sample, worked fine. Here is the link to Jenkins Job with the changes - http://9.124.102.159:8080/job/Watson-IoT-Python/163/