### PR TITLE
Add capability to use websockets

### DIFF
--- a/src/ibmiotf/__init__.py
+++ b/src/ibmiotf/__init__.py
@@ -38,7 +38,7 @@ class Message:
         self.timestamp = timestamp
 
 class AbstractClient:
-    def __init__(self, domain, organization, clientId, username, password, port=8883, logHandlers=None, cleanSession="true"):
+    def __init__(self, domain, organization, clientId, username, password, port=8883, logHandlers=None, cleanSession="true", transport="tcp"):
         self.organization = organization
         self.username = username
         self.password = password
@@ -93,7 +93,7 @@ class AbstractClient:
             self.logger.addHandler(rfh)
             self.logger.addHandler(ch)
 
-        self.client = paho.Client(self.clientId, clean_session=False if cleanSession == "false" else True)
+        self.client = paho.Client(self.clientId, transport=transport, clean_session=False if cleanSession == "false" else True)
 
         try:
             self.tlsVersion = ssl.PROTOCOL_TLSv1_2

--- a/src/ibmiotf/application.py
+++ b/src/ibmiotf/application.py
@@ -169,6 +169,8 @@ class Client(ibmiotf.AbstractClient):
             self._options["port"] = 8883;
         if self._options["org"] == "quickstart":
             self._options["port"] = 1883;
+        if "transport" not in self._options:
+            self._options["transport"] = "tcp"
 
         ### REQUIRED ###
         if 'auth-key' not in self._options or self._options['auth-key'] is None:
@@ -200,7 +202,8 @@ class Client(ibmiotf.AbstractClient):
             password = password,
             logHandlers = logHandlers,
             cleanSession = self._options['clean-session'],
-            port = self._options['port']
+            port = self._options['port'],
+            transport = self._options['transport']
         )
 
         # Add handler for subscriptions

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -76,6 +76,9 @@ class Client(AbstractClient):
         if self._options["org"] == "quickstart":
             self._options["port"] = 1883;
 
+        if "transport" not in self._options:
+            self._options["transport"] = "tcp"
+
         ### REQUIRED ###
         if self._options['org'] == None:
             raise ConfigurationException("Missing required property: org")
@@ -103,7 +106,8 @@ class Client(AbstractClient):
             password = self._options['auth-token'],
             logHandlers = logHandlers,
             cleanSession = self._options['clean-session'],
-            port = self._options['port']
+            port = self._options['port'],
+            transport = self._options['transport']
         )
 
         # Add handler for commands if not connected to QuickStart

--- a/src/ibmiotf/gateway.py
+++ b/src/ibmiotf/gateway.py
@@ -78,6 +78,9 @@ class Client(AbstractClient):
         if self._options["org"] == "quickstart":
             self._options["port"] = 1883;
 
+        if "transport" not in self._options:
+            self._options["transport"] = "tcp"
+
         #Check for any missing required properties
         if self._options['org'] == None:
             raise ConfigurationException("Missing required property: org")
@@ -107,7 +110,8 @@ class Client(AbstractClient):
             username = "use-token-auth" if (self._options['auth-method'] == "token") else None,
             password = self._options['auth-token'],
             logHandlers = logHandlers,
-            port = self._options['port']
+            port = self._options['port'],
+            transport = self._options['transport']
         )
 
         # Add handler for subscriptions


### PR DESCRIPTION
The paho python library supports websockets, so it's only a minor change to switch. Still keeps the default of tcp transport for existing applications unless otherwise specified