### PR TITLE
Travis CI: Add Python 3.7 and flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
-sudo: false
+group: travis_latest
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+cache: pip
+matrix:
+  include:
+    - python: "2.7"
+    - python: "3.4.3"  # See README.md
+    - python: "3.5"
+    - python: "3.6"
+    - python: "3.7"
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install: pip install tox-travis
 script: tox

--- a/samples/customMessageFormat/customCodecSample.py
+++ b/samples/customMessageFormat/customCodecSample.py
@@ -39,8 +39,6 @@ def myAppEventCallback(event):
 	print("Received live data from %s (%s) sent at %s: hello=%s x=%s" % (event.deviceId, event.deviceType, event.timestamp.strftime("%H:%M:%S"), data['hello'], data['x']))
 
 
-
-
 try:
 	opts, args = getopt.getopt(sys.argv[1:], "a:d:", ["app=", "device="])
 except getopt.GetoptError as err:

--- a/samples/deviceDataTransformation/activate.py
+++ b/samples/deviceDataTransformation/activate.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
   verify = None
   params = {"auth-key": properties.key, "auth-token": properties.token}
   if "domain" in property_names:
-    params["domain"] = domain
+    params["domain"] = properties.domain
 
   if "verify" in property_names:
     verify = properties.verify

--- a/samples/deviceDataTransformation/cleardevice.py
+++ b/samples/deviceDataTransformation/cleardevice.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     print("Application interfaces found:", ids)
     print("Schemas found:", schemaIds)
   except:
-    ids = result = []    
+    ids = result = []
 
   # disassociate and delete the application interfaces from the device type
   count = 0
@@ -56,7 +56,7 @@ if __name__ == "__main__":
   # delete the application interface schemas
   count = 0
   for schemaId in schemaIds:
-    result = deleteSchema(applicationInterfaceId)
+    result = api.deleteSchema(applicationInterfaceId)
     count += 1
   print("Application interface schemas deleted:", count, schemaIds)
 
@@ -75,8 +75,8 @@ if __name__ == "__main__":
     for eventId in eventIds:
      	result = api.deleteEvent(physicalInterfaceId, eventId) # remove event mapping from device type
 
-  	result = api.deletePhysicalInterface(physicalInterfaceId)
-  	print("Physical interface deleted")
+    result = api.deletePhysicalInterface(physicalInterfaceId)
+    print("Physical interface deleted")
 
     # delete event types and schemas
     count = 0; schemaIds = []

--- a/samples/deviceDataTransformation/cleardevice.py
+++ b/samples/deviceDataTransformation/cleardevice.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
   # delete the application interface schemas
   count = 0
   for schemaId in schemaIds:
-    result = deleteSchema(schemaId)
+    result = api.deleteSchema(schemaId)
     count += 1
   print("Application interface schemas deleted:", count, schemaIds)
 

--- a/samples/deviceDataTransformation/cleardevicetype.py
+++ b/samples/deviceDataTransformation/cleardevicetype.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
   verify = None
   params = {"auth-key": properties.key, "auth-token": properties.token}
   if "domain" in property_names:
-    params["domain"] = domain
+    params["domain"] = properties.domain
 
   if "verify" in property_names:
     verify = properties.verify

--- a/samples/deviceDataTransformation/clearorphaned.py
+++ b/samples/deviceDataTransformation/clearorphaned.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
   verify = None
   params = {"auth-key": properties.key, "auth-token": properties.token}
   if "domain" in property_names:
-    params["domain"] = domain
+    params["domain"] = properties.domain
 
   if "verify" in property_names:
     verify = properties.verify

--- a/samples/deviceDataTransformation/define.py
+++ b/samples/deviceDataTransformation/define.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
   verify = None
   params = {"auth-key": properties.key, "auth-token": properties.token}
   if "domain" in property_names:
-    params["domain"] = domain
+    params["domain"] = properties.domain
 
   if "verify" in property_names:
     verify = properties.verify

--- a/samples/deviceDataTransformation/getlastevents.py
+++ b/samples/deviceDataTransformation/getlastevents.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
   verify = None
   params = {"auth-key": properties.key, "auth-token": properties.token}
   if "domain" in property_names:
-    params["domain"] = domain
+    params["domain"] = properties.domain
 
   if "verify" in property_names:
     verify = properties.verify

--- a/samples/deviceDataTransformation/getstate.py
+++ b/samples/deviceDataTransformation/getstate.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
   verify = None
   params = {"auth-key": properties.key, "auth-token": properties.token}
   if "domain" in property_names:
-    params["domain"] = domain
+    params["domain"] = properties.domain
 
   if "verify" in property_names:
     verify = properties.verify

--- a/samples/deviceDataTransformation/query.py
+++ b/samples/deviceDataTransformation/query.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
   verify = None
   params = {"auth-key": properties.key, "auth-token": properties.token}
   if "domain" in property_names:
-    params["domain"] = domain
+    params["domain"] = properties.domain
 
   if "verify" in property_names:
     verify = properties.verify

--- a/samples/deviceDataTransformation/subscribe_notifications.py
+++ b/samples/deviceDataTransformation/subscribe_notifications.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
   verify = None
   params = {"auth-key": properties.key, "auth-token": properties.token}
   if "domain" in property_names:
-    params["domain"] = domain
+    params["domain"] = properties.domain
 
   if "verify" in property_names:
     verify = properties.verify

--- a/samples/deviceDataTransformation/validate.py
+++ b/samples/deviceDataTransformation/validate.py
@@ -13,33 +13,33 @@
 from __future__ import print_function
 import time, ibmiotf.api
 
-if __name__ == "__main__":    
+
+if __name__ == "__main__":
   domain = None
   verify = True
   from properties import orgid, key, token, devicetype, deviceid
-  
+
   try:
     from properties import domain
   except:
     pass
-    
+
   try:
     from properties import verify
   except:
     pass
-  
+
   params = {"auth-key": key, "auth-token": token}
   if domain:
     params["domain"] = domain
-  
+
   api = ibmiotf.api.ApiClient(params)
   api.verify = verify
 
   try:
-	result = api.validateDeviceTypeConfiguration(devicetype)
+    result = api.validateDeviceTypeConfiguration(devicetype)
   except ibmiotf.APIException as exc:
-	print(exc.response)
-	print(exc.response.json())
-	  
+    print(exc.response)
+    print(exc.response.json())
+
   print(result)
-  

--- a/samples/gatewayExamples/gatewaySubscribeCommand.py
+++ b/samples/gatewayExamples/gatewaySubscribeCommand.py
@@ -11,15 +11,11 @@
 # *****************************************************************************
 
 import signal
-import time
 import sys
-import pprint
-import uuid
 from time import sleep
 
-
 try:
-    import ibmiotf.application
+	import ibmiotf.application
 	import ibmiotf.gateway
 except ImportError:
 	# This part is only required to run the sample from within the samples
@@ -87,4 +83,3 @@ while True:
 	sleep(1)
 # Disconnect the device and application from the cloud
 gatewayCli.disconnect()
-

--- a/samples/managedDevice/DeviceAndFirmwareActions.py
+++ b/samples/managedDevice/DeviceAndFirmwareActions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # *****************************************************************************
 # Copyright (c) 2016 IBM Corporation and other Contributors.
 #
@@ -123,7 +124,7 @@ def downloadHandler(client,info):
         f = open(file_name, 'wb')
         meta = u.info()
         file_size = int(meta.getheaders("Content-Length")[0])
-        print "Downloading: %s Bytes: %s" % (file_name, file_size)
+        print("Downloading: %s Bytes: %s" % (file_name, file_size))
         
         file_size_dl = 0
         block_sz = 8192
@@ -136,7 +137,7 @@ def downloadHandler(client,info):
             f.write(buffer)
             status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
             status = status + chr(8)*(len(status)+1)
-            print status,
+            print(status, end=' ')
         
         f.close()
         client.setState(ManagedClient.UPDATESTATE_DOWNLOADED)

--- a/samples/managedDevice/dmeAction.py
+++ b/samples/managedDevice/dmeAction.py
@@ -61,6 +61,7 @@
 
         10. Cleanup and Sample Terminates by accepting q from user.
 '''
+from __future__ import print_function
 
 # Import required modules
 import ibmiotf.device
@@ -69,6 +70,12 @@ import ibmiotf.api
 import logging
 import threading
 import json
+
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 
 # Define callback for Received Device events at Application Client Side
 def deviceEventCallback(event):
@@ -195,8 +202,8 @@ mgmtRequest = {"action": "example-dme-actions-v1/updatePublishInterval",
                                  "value": 10,}],
                "devices": [{ "typeId": deviceType, "deviceId": deviceId }]}
 while(True):
-    print "Device events getting published for every %s seconds" %(pInterval)
-    print "Enter Seconds to update Publish Interval / q to Quit"
+    print("Device events getting published for every %s seconds" %(pInterval))
+    print("Enter Seconds to update Publish Interval / q to Quit")
     flag = raw_input("Waiting for your Input  :")
     if flag == 'q':
         pThread.cancel()
@@ -215,7 +222,7 @@ while(True):
         updPubReqId = initResult['reqId']
 
     else:
-        print "Invalid Input, try again!"
+        print("Invalid Input, try again!")
 
 
 # It's time of clear of DME and DM request from the IoT Platform

--- a/src/ibmiotf/api/common.py
+++ b/src/ibmiotf/api/common.py
@@ -2,6 +2,8 @@ import requests
 import logging
 import json
 
+from ibmiotf import ConfigurationException
+
 class ApiClient():
     def __init__(self, options, logger=None):
         self.__options = options
@@ -14,9 +16,9 @@ class ApiClient():
         self.logger = logger
 
         if 'auth-key' not in self.__options or self.__options['auth-key'] is None:
-            raise ibmiotf.ConfigurationException("Missing required property for API key based authentication: auth-key")
+            raise ConfigurationException("Missing required property for API key based authentication: auth-key")
         if 'auth-token' not in self.__options or self.__options['auth-token'] is None:
-            raise ibmiotf.ConfigurationException("Missing required property for API key based authentication: auth-token")
+            raise ConfigurationException("Missing required property for API key based authentication: auth-token")
 
         # Get the orgId from the apikey
         self.__options['org'] = self.__options['auth-key'][2:8]
@@ -110,4 +112,3 @@ class IterableList(object):
             return r.json()
         else:
             raise Exception("HTTP %s %s" % (r.status_code, r.text))
-

--- a/src/ibmiotf/api/common.py
+++ b/src/ibmiotf/api/common.py
@@ -15,9 +15,9 @@ class ApiClient():
 
         self.logger = logger
 
-        if 'auth-key' not in self.__options or self.__options['auth-key'] is None:
+        if self.__options.get('auth-key') is None:
             raise ConfigurationException("Missing required property for API key based authentication: auth-key")
-        if 'auth-token' not in self.__options or self.__options['auth-token'] is None:
+        if self.__options.get('auth-token') is None:
             raise ConfigurationException("Missing required property for API key based authentication: auth-token")
 
         # Get the orgId from the apikey

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,18 @@
 # tox -e py27 -- test/test_api_registry_devices.py
 
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
-commands = pytest {posargs}
-passenv = WIOTP_API_KEY WIOTP_API_TOKEN WIOTP_ORG_ID
 deps =
-    pytest
+    flake8
     nose
+    pytest
+commands =
+    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    pytest {posargs}
+passenv = WIOTP_API_KEY WIOTP_API_TOKEN WIOTP_ORG_ID
+
 
 [pytest]
 minversion=2.0


### PR DESCRIPTION
* Added Python 3.7 to Travis CI and tox in alignment with travis-ci/travis-ci#9069
* Specified Python 3.4.3 in Travis CI and tox in alignment with READ.md
* Added [flake8](http://flake8.pycqa.org) tests to look for Python syntax errors and undefined names
    * __print()__ is a function in Python 3
    * Mixing tab and space indentation is a [__TabError__](https://stackoverflow.com/questions/18225712/taberror-in-python-3) which Python 3 treats as a syntax error
    * __raw_input()__ was removed in Python 3 in favor of __input()__
    * Fixed several undefined names ~and opened #114, #115, #116 for issues I could not resolve~


__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree