### PR TITLE
Remove Python 3.4 because it is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ cache: pip
 matrix:
   include:
     - python: "2.7"
-    - python: "3.4.3"  # See README.md
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      dist: xenial    # required for Python >= 3.7
 install: pip install tox-travis coveralls
 script: tox
 after_success:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 Python module for interacting with the [IBM Watson IoT Platform](https://internetofthings.ibmcloud.com).
 
--  [Python 3.7](https://www.python.org/downloads/release/python-370/)
--  [Python 2.7](https://www.python.org/downloads/release/python-2715/)
+-  [Python 3.7](https://www.python.org/downloads/release/python-373/)  (recommended)
+-  [Python 2.7](https://www.python.org/downloads/release/python-2716/)
 
-Note: Support for MQTT with TLS requires at least Python v2.7.9 or v3.4, and openssl v1.0.1
+Note: Support for MQTT with TLS requires at least Python v2.7.9 and openssl v1.0.1
 
 
 ## Dependencies

--- a/samples/customMessageFormat/myCustomCodec.py
+++ b/samples/customMessageFormat/myCustomCodec.py
@@ -22,13 +22,14 @@ except ImportError:
     if cmd_subfolder not in sys.path:
         sys.path.insert(0, cmd_subfolder)
     from wiotp.sdk import Message
-    
-def MyCodec(wiotp.sdk.MessageCodec):
+
+
+class MyCodec(MessageCodec):
     '''
     Dedicated encoder for supporting a very specific dataset, serialises a dictionary object
-    of the following format: 
+    of the following format:
         {
-            'hello' : 'world', 
+            'hello' : 'world',
             'x' : 10
         }
 
@@ -43,18 +44,18 @@ def MyCodec(wiotp.sdk.MessageCodec):
     @staticmethod
     def decode(message):
         '''
-        The decoder understands the comma-seperated format produced by the encoder and 
+        The decoder understands the comma-seperated format produced by the encoder and
         allocates the two values to the correct keys:
             data['hello'] = 'world'
             data['x'] = 10
-          
+
         '''
         (hello, x) = message.payload.split(",")
-        
+
         data = {}
         data['hello'] = hello
         data['x'] = x
-        
+
         timestamp = datetime.now(pytz.timezone('UTC'))
-        
+
         return Message(data, timestamp)

--- a/samples/simpleDevice/simpleDevice.py
+++ b/samples/simpleDevice/simpleDevice.py
@@ -58,6 +58,7 @@ if args.token:
 # Initialize the device client.
 
 try:
+    import wiotp
     if args.cfg is not None:
         deviceOptions = wiotp.sdk.device.parseConfigFile(args.cfg)
     else:

--- a/src/wiotp/sdk/device/config.py
+++ b/src/wiotp/sdk/device/config.py
@@ -28,7 +28,7 @@ class DeviceClientConfig(defaultdict):
             raise ConfigurationException("Missing identity.deviceId from configuration")
 
         # Authentication is not supported for quickstart
-        if kwargs["identity"]["orgId"] is "quickstart":
+        if kwargs["identity"]["orgId"] == "quickstart":
             if "auth" in kwargs:
                 raise ConfigurationException("Quickstart service does not support device authentication")
         else:
@@ -143,7 +143,7 @@ class DeviceClientConfig(defaultdict):
 
 def parseEnvVars():
     """
-    Parse environment variables into a Python dictionary suitable for passing to the 
+    Parse environment variables into a Python dictionary suitable for passing to the
     device client constructor as the `options` parameter
 
     - `WIOTP_IDENTITY_ORGID`
@@ -183,7 +183,7 @@ def parseEnvVars():
         raise ConfigurationException("Missing WIOTP_IDENTITY_TYPEID environment variable")
     if deviceId is None:
         raise ConfigurationException("Missing WIOTP_IDENTITY_DEVICEID environment variable")
-    if orgId is not "quickstart" and authToken is None:
+    if orgId != "quickstart" and authToken is None:
         raise ConfigurationException("Missing WIOTP_AUTH_TOKEN environment variable")
     if port is not None:
         try:
@@ -232,11 +232,11 @@ def parseEnvVars():
 
 def parseConfigFile(configFilePath):
     """
-    Parse a yaml configuration file into a Python dictionary suitable for passing to the 
+    Parse a yaml configuration file into a Python dictionary suitable for passing to the
     device client constructor as the `options` parameter
-    
+
     # Example Configuration File
-    
+
     identity:
       orgId: org1id
       typeId: raspberry-pi-3
@@ -253,7 +253,7 @@ def parseConfigFile(configFilePath):
         sessionExpiry: 3600
         keepAlive: 60
         caFile: /path/to/certificateAuthorityFile.pem
-    
+
     """
 
     try:

--- a/tmp/src/things/things.py
+++ b/tmp/src/things/things.py
@@ -1,3 +1,4 @@
+    # flake8: noqa  # This entire file is improperly indented
     # Information management URLs
 
     # Draft Device type URLs
@@ -37,30 +38,30 @@
 
     # Device state
     deviceStateUrl = "https://%s/api/v0002/device/types/%s/devices/%s/state/%s"
-    
+
     # Thing Types URLs
     thingTypesUrl   = "https://%s/api/v0002/thing/types"
     thingTypeUrl    = "https://%s/api/v0002/thing/types/%s"
-    
+
     # Thing URLs
     thingsUrl   = "https://%s/api/v0002/thing/types/%s/things"
     thingUrl    = "https://%s/api/v0002/thing/types/%s/things/%s"
-    
+
     # Draft Thing type URLs
     draftThingTypesUrl  = 'https://%s/api/v0002/draft/thing/types'
     draftThingTypeUrl   = 'https://%s/api/v0002/draft/thing/types/%s'
-    
+
     # Thing types logical interface URLs
     allThingTypeLogicalInterfacesUrl = "https://%s/api/v0002%s/thing/types/%s/logicalinterfaces"
     oneThingTypeLogicalInterfaceUrl = "https://%s/api/v0002/draft/thing/types/%s/logicalinterfaces/%s"
-    
+
     # Thing Mappings
     allThingTypeMappingsUrl = "https://%s/api/v0002%s/thing/types/%s/mappings"
     oneThingTypeMappingUrl = "https://%s/api/v0002%s/thing/types/%s/mappings/%s"
-    
+
     # Thing state
     thingStateUrl = "https://%s/api/v0002/thing/types/%s/things/%s/state/%s"
-    
+
     """
     Thing API methods
      - register a new thing
@@ -69,7 +70,7 @@
      - remove thing
      - update thing
     """
-    
+
     def registerThing(self, thingTypeId, thingId, name = None, description = None, aggregatedObjects = None, metadata=None):
         """
         Registers a new thing.
@@ -98,7 +99,7 @@
             raise ibmiotf.APIException(500, "Unexpected error", None)
         else:
             raise ibmiotf.APIException(None, "Unexpected error", None)
-        
+
     def getThing(self, thingTypeId, thingId):
         """
         Gets thing details.
@@ -205,9 +206,9 @@
             raise ibmiotf.APIException(500, "Unexpected error", None)
         else:
             raise ibmiotf.APIException(None, "Unexpected error", None)
-        
-    
-    
+
+
+
     """
     Thing Types API methods
      - Add thing type
@@ -216,7 +217,7 @@
      - update thing type
      - remove thing type
     """
-    
+
     def addDraftThingType(self, thingTypeId, name = None, description = None, schemaId = None, metadata = None):
         """
         Creates a thing type.
@@ -243,7 +244,7 @@
             raise ibmiotf.APIException(500, "Unexpected error", None)
         else:
             raise ibmiotf.APIException(None, "Unexpected error", None)
-        
+
     def updateDraftThingType(self, thingTypeId, name, description, schemaId, metadata = None):
         """
         Updates a thing type.
@@ -269,7 +270,7 @@
             raise ibmiotf.APIException(500, "Unexpected error", None)
         else:
             raise ibmiotf.APIException(None, "Unexpected error", None)
-    
+
     def getDraftThingTypes(self, parameters = None):
         """
         Retrieves all existing draft thing types.
@@ -291,7 +292,7 @@
             raise ibmiotf.APIException(500, "Unexpected error", None)
         else:
             raise ibmiotf.APIException(None, "Unexpected error", None)
-    
+
     def getDraftThingType(self, thingTypeId, parameters = None):
         """
         Retrieves all existing draft thing types.
@@ -317,7 +318,7 @@
             raise ibmiotf.APIException(500, "Unexpected error", None)
         else:
             raise ibmiotf.APIException(None, "Unexpected error", None)
-            
+
     def deleteDraftThingType(self, thingTypeId):
         """
         Deletes a Thing type.
@@ -343,7 +344,7 @@
             raise ibmiotf.APIException(500, "Unexpected error", None)
         else:
             raise ibmiotf.APIException(None, "Unexpected error", None)
-        
+
     def getActiveThingTypes(self, parameters = None):
         """
         Retrieves all existing active thing types.
@@ -367,7 +368,7 @@
             raise ibmiotf.APIException(500, "Unexpected error", None)
         else:
             raise ibmiotf.APIException(None, "Unexpected error", None)
-        
+
     def getActiveThingType(self, thingTypeId, parameters = None):
         """
         Retrieves all existing Active thing types.
@@ -931,7 +932,7 @@
     def addRuleToLogicalInterface(self, logicalInterfaceId, name, condition, description=None, alias=None):
         """
         Adds a rule to a logical interface.
-        Parameters: 
+        Parameters:
           - logicalInterfaceId (string)
           - name (string)
           - condition (string)
@@ -954,7 +955,7 @@
     def updateRuleOnLogicalInterface(self, logicalInterfaceId, ruleId, name, condition, description=None):
         """
         Updates a rule on a logical interface..
-        Parameters: 
+        Parameters:
           - logicalInterfaceId (string),
           - ruleId (string)
           - name (string)
@@ -978,7 +979,7 @@
     def deleteRuleOnLogicalInterface(self, logicalInterfaceId, ruleId):
         """
         Deletes a rule from a logical interface
-        Parameters: 
+        Parameters:
           - logicalInterfaceId (string),
           - ruleId (string)
         Returns: response (object)
@@ -1363,13 +1364,13 @@
         else:
             raise ibmiotf.APIException(resp.status_code, "HTTP error getting state for a logical interface from a device type", resp)
         return resp.json()
-    
+
     """
     ===========================================================================
     Information Management Things APIs
     ===========================================================================
     """
-    
+
     def validateThingTypeConfiguration(self, thingTypeId):
         """
         Validate the thing type configuration.
@@ -1420,7 +1421,7 @@
         else:
             raise ibmiotf.APIException(resp.status_code, "Deactivation for thing type configuration failed", resp)
         return resp.json()
-    
+
     def getThingStateForLogicalInterface(self, thingTypeId, thingId, logicalInterfaceId):
         """
         Gets the state for a logical interface for a thing.
@@ -1463,7 +1464,7 @@
     Information Management Things type APIs
     ===========================================================================
     """
-    
+
     def getLogicalInterfacesOnThingType(self, thingTypeId, draft=False):
         """
         Get all logical interfaces for a thing type.
@@ -1522,7 +1523,7 @@
         else:
             raise ibmiotf.APIException(resp.status_code, "HTTP error removing logical interface from a thing type", resp)
         return resp
-    
+
     def getMappingsOnThingType(self, thingTypeId, draft=False):
         """
         Get all the mappings for a thing type.
@@ -1646,5 +1647,5 @@
         else:
             raise ibmiotf.APIException(resp.status_code, "HTTP error updating thing type mappings for logical interface", resp)
         return resp.json()
-        
-        
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,14 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 #
-# tox -e py27 -- test/test_api_registry_devices.py
+# tox -e py37 -- test/test_api_registry_devices.py
 #
 # Sometimes tox fails to install the module being developed ... if hit this again
 # add the following line to commands list
 #         python setup.py install
 
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py35, py36, py37
 
 [testenv]
 deps =
@@ -20,10 +20,10 @@ deps =
     pytest-cov
     coverage
 commands =
-    flake8 src --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
     pytest --cov=wiotp.sdk {posargs}
-passenv = 
-    WIOTP_API_KEY WIOTP_API_TOKEN 
+passenv =
+    WIOTP_API_KEY WIOTP_API_TOKEN
     WIOTP_OPTIONS_DOMAIN WIOTP_OPTIONS_HTTP_VERIFY
     CLOUDANT_HOST CLOUDANT_PORT CLOUDANT_USERNAME CLOUDANT_PASSWORD
     EVENTSTREAMS_API_KEY EVENTSTREAMS_ADMIN_URL EVENTSTREAMS_USER EVENTSTREAMS_PASSWORD


### PR DESCRIPTION
Remove support for Python 3.4 because that release has reached its end of life.
* https://devguide.python.org/devcycle/#end-of-life-branches

Also run flake8 on the whole repo because samples, etc. have issues and add a few more flake8 tests esp. __F632 use ==/!= to compare str, bytes, and int literals__.