### PR TITLE
EnvironmentVariable Device Config Tests

### DIFF
--- a/test/testUtils/__init__.py
+++ b/test/testUtils/__init__.py
@@ -19,10 +19,10 @@ class AbstractTest(object):
     WIOTP_API_KEY=os.getenv("WIOTP_API_KEY")
     WIOTP_API_TOKEN=os.getenv("WIOTP_API_TOKEN")
 
-    CLOUDANT_HOST=os.getenv("CLOUDANT_HOST",None)
-    CLOUDANT_PORT=os.getenv("CLOUDANT_PORT",None)
-    CLOUDANT_USERNAME=os.getenv("CLOUDANT_USERNAME",None)
-    CLOUDANT_PASSWORD=os.getenv("CLOUDANT_PASSWORD",None)
+    CLOUDANT_HOST=os.getenv("CLOUDANT_HOST")
+    CLOUDANT_PORT=os.getenv("CLOUDANT_PORT")
+    CLOUDANT_USERNAME=os.getenv("CLOUDANT_USERNAME")
+    CLOUDANT_PASSWORD=os.getenv("CLOUDANT_PASSWORD")
 
 
     EVENTSTREAMS_API_KEY=os.getenv("EVENTSTREAMS_API_KEY")
@@ -47,7 +47,14 @@ class AbstractTest(object):
     if ORG_ID is None:
         raise Exception("Unable to set ORG_ID from WIOTP_API_KEY")
 
-  
+    if CLOUDANT_HOST is None:
+        raise Exception("CLOUDANT_HOST environment variable is not set")
+    if CLOUDANT_PORT is None:
+        raise Exception("CLOUDANT_PORT environment variable is not set")
+    if CLOUDANT_USERNAME is None:
+        raise Exception("CLOUDANT_USERNAME environment variable is not set")
+    if CLOUDANT_PASSWORD is None:
+        raise Exception("CLOUDANT_PASSWORD environment variable is not set")
 
     options = wiotp.sdk.application.parseEnvVars()
     # import pprint

--- a/test/testUtils/__init__.py
+++ b/test/testUtils/__init__.py
@@ -19,10 +19,10 @@ class AbstractTest(object):
     WIOTP_API_KEY=os.getenv("WIOTP_API_KEY")
     WIOTP_API_TOKEN=os.getenv("WIOTP_API_TOKEN")
 
-    CLOUDANT_HOST=os.getenv("CLOUDANT_HOST")
-    CLOUDANT_PORT=os.getenv("CLOUDANT_PORT")
-    CLOUDANT_USERNAME=os.getenv("CLOUDANT_USERNAME")
-    CLOUDANT_PASSWORD=os.getenv("CLOUDANT_PASSWORD")
+    CLOUDANT_HOST=os.getenv("CLOUDANT_HOST",None)
+    CLOUDANT_PORT=os.getenv("CLOUDANT_PORT",None)
+    CLOUDANT_USERNAME=os.getenv("CLOUDANT_USERNAME",None)
+    CLOUDANT_PASSWORD=os.getenv("CLOUDANT_PASSWORD",None)
 
 
     EVENTSTREAMS_API_KEY=os.getenv("EVENTSTREAMS_API_KEY")
@@ -47,14 +47,7 @@ class AbstractTest(object):
     if ORG_ID is None:
         raise Exception("Unable to set ORG_ID from WIOTP_API_KEY")
 
-    if CLOUDANT_HOST is None:
-        raise Exception("CLOUDANT_HOST environment variable is not set")
-    if CLOUDANT_PORT is None:
-        raise Exception("CLOUDANT_PORT environment variable is not set")
-    if CLOUDANT_USERNAME is None:
-        raise Exception("CLOUDANT_USERNAME environment variable is not set")
-    if CLOUDANT_PASSWORD is None:
-        raise Exception("CLOUDANT_PASSWORD environment variable is not set")
+  
 
     options = wiotp.sdk.application.parseEnvVars()
     # import pprint

--- a/test/testUtils/__init__.py
+++ b/test/testUtils/__init__.py
@@ -19,10 +19,10 @@ class AbstractTest(object):
     WIOTP_API_KEY=os.getenv("WIOTP_API_KEY")
     WIOTP_API_TOKEN=os.getenv("WIOTP_API_TOKEN")
 
-    CLOUDANT_HOST=os.getenv("CLOUDANT_HOST",None)
-    CLOUDANT_PORT=os.getenv("CLOUDANT_PORT",None)
-    CLOUDANT_USERNAME=os.getenv("CLOUDANT_USERNAME",None)
-    CLOUDANT_PASSWORD=os.getenv("CLOUDANT_PASSWORD",None)
+    CLOUDANT_HOST=os.getenv("CLOUDANT_HOST")
+    CLOUDANT_PORT=os.getenv("CLOUDANT_PORT")
+    CLOUDANT_USERNAME=os.getenv("CLOUDANT_USERNAME")
+    CLOUDANT_PASSWORD=os.getenv("CLOUDANT_PASSWORD")
 
 
     EVENTSTREAMS_API_KEY=os.getenv("EVENTSTREAMS_API_KEY")
@@ -34,7 +34,6 @@ class AbstractTest(object):
     EVENTSTREAMS_BROKER5=os.getenv("EVENTSTREAMS_BROKER5")
     EVENTSTREAMS_USER=os.getenv("EVENTSTREAMS_USER")
     EVENTSTREAMS_PASSWORD=os.getenv("EVENTSTREAMS_PASSWORD")
-
 
     try:
         ORG_ID = WIOTP_API_KEY.split("-")[1]
@@ -48,7 +47,14 @@ class AbstractTest(object):
     if ORG_ID is None:
         raise Exception("Unable to set ORG_ID from WIOTP_API_KEY")
 
-  
+    if CLOUDANT_HOST is None:
+        raise Exception("CLOUDANT_HOST environment variable is not set")
+    if CLOUDANT_PORT is None:
+        raise Exception("CLOUDANT_PORT environment variable is not set")
+    if CLOUDANT_USERNAME is None:
+        raise Exception("CLOUDANT_USERNAME environment variable is not set")
+    if CLOUDANT_PASSWORD is None:
+        raise Exception("CLOUDANT_PASSWORD environment variable is not set")
 
     options = wiotp.sdk.application.parseEnvVars()
     # import pprint

--- a/test/testUtils/__init__.py
+++ b/test/testUtils/__init__.py
@@ -35,6 +35,7 @@ class AbstractTest(object):
     EVENTSTREAMS_USER=os.getenv("EVENTSTREAMS_USER")
     EVENTSTREAMS_PASSWORD=os.getenv("EVENTSTREAMS_PASSWORD")
 
+
     try:
         ORG_ID = WIOTP_API_KEY.split("-")[1]
     except:

--- a/test/test_device_cfg.py
+++ b/test/test_device_cfg.py
@@ -11,6 +11,7 @@
 import wiotp.sdk.device
 import testUtils
 import pytest
+import os
 
 class TestDeviceCfg(testUtils.AbstractTest):
 
@@ -23,7 +24,7 @@ class TestDeviceCfg(testUtils.AbstractTest):
         with pytest.raises(wiotp.sdk.ConfigurationException) as e:
             wiotp.sdk.device.DeviceClient({
                 "identity": {
-                    "orgId": None, "typeId": "myType", "deviceId": "myId"
+                    "orgId": None, "typeId": "myType", "deviceId": "myDevice"
                 },
                 "auth": { "token" : "myToken" }
             })
@@ -33,7 +34,7 @@ class TestDeviceCfg(testUtils.AbstractTest):
         with pytest.raises(wiotp.sdk.ConfigurationException) as e:
             wiotp.sdk.device.DeviceClient({
                 "identity": {
-                    "orgId": "myOrg", "typeId": None, "deviceId": "myId"
+                    "orgId": "myOrg", "typeId": None, "deviceId": "myDevice"
                 },
                 "auth": { "token" : "myToken" }
             })
@@ -53,7 +54,7 @@ class TestDeviceCfg(testUtils.AbstractTest):
         with pytest.raises(wiotp.sdk.ConfigurationException) as e:
             wiotp.sdk.device.DeviceClient({
                 "identity": {
-                    "orgId": "myOrg", "typeId": "myType", "deviceId": "myId"
+                    "orgId": "myOrg", "typeId": "myType", "deviceId": "myDevice"
                 },
                 "auth": { "token" : None }
             })
@@ -66,3 +67,36 @@ class TestDeviceCfg(testUtils.AbstractTest):
         with pytest.raises(wiotp.sdk.ConfigurationException) as e:
             wiotp.sdk.device.parseConfigFile(deviceFile)
         assert e.value.reason == "Error reading device configuration file 'InvalidFile.out' ([Errno 2] No such file or directory: 'InvalidFile.out')"
+
+    def testMissingOrgIDEnvVar(self):
+        with pytest.raises(wiotp.sdk.ConfigurationException) as e:
+           os.environ['WIOTP_IDENTITY_ORGID'] = "myOrg"
+           os.environ['WIOTP_IDENTITY_TYPEID'] = "myType"
+           os.environ['WIOTP_IDENTITY_DEVICEID'] = "myDevice"
+           os.environ['WIOTP_AUTH_TOKEN'] = "myToken"
+
+           del os.environ['WIOTP_IDENTITY_ORGID']
+           wiotp.sdk.device.parseEnvVars()
+        assert e.value.reason == "Missing WIOTP_IDENTITY_ORGID environment variable"
+    
+    def testMissingTypeIDEnvVar(self):
+        with pytest.raises(wiotp.sdk.ConfigurationException) as e:
+           os.environ['WIOTP_IDENTITY_ORGID'] = "myOrg"
+           os.environ['WIOTP_IDENTITY_TYPEID'] = "myType"
+           os.environ['WIOTP_IDENTITY_DEVICEID'] = "myDevice"
+           os.environ['WIOTP_AUTH_TOKEN'] = "myToken"
+
+           del os.environ['WIOTP_IDENTITY_TYPEID']
+           wiotp.sdk.device.parseEnvVars()
+        assert e.value.reason == "Missing WIOTP_IDENTITY_TYPEID environment variable"
+
+    def testMissingDeviceIDEnvVar(self):
+        with pytest.raises(wiotp.sdk.ConfigurationException) as e:
+           os.environ['WIOTP_IDENTITY_ORGID'] = "myOrg"
+           os.environ['WIOTP_IDENTITY_TYPEID'] = "myType"
+           os.environ['WIOTP_IDENTITY_DEVICEID'] = "myDevice"
+           os.environ['WIOTP_AUTH_TOKEN'] = "myToken"
+
+           del os.environ['WIOTP_IDENTITY_DEVICEID']
+           wiotp.sdk.device.parseEnvVars()
+        assert e.value.reason == "Missing WIOTP_IDENTITY_DEVICEID environment variable"

--- a/test/test_device_cfg.py
+++ b/test/test_device_cfg.py
@@ -11,7 +11,6 @@
 import wiotp.sdk.device
 import testUtils
 import pytest
-import os
 
 class TestDeviceCfg(testUtils.AbstractTest):
 
@@ -24,7 +23,7 @@ class TestDeviceCfg(testUtils.AbstractTest):
         with pytest.raises(wiotp.sdk.ConfigurationException) as e:
             wiotp.sdk.device.DeviceClient({
                 "identity": {
-                    "orgId": None, "typeId": "myType", "deviceId": "myDevice"
+                    "orgId": None, "typeId": "myType", "deviceId": "myId"
                 },
                 "auth": { "token" : "myToken" }
             })
@@ -34,7 +33,7 @@ class TestDeviceCfg(testUtils.AbstractTest):
         with pytest.raises(wiotp.sdk.ConfigurationException) as e:
             wiotp.sdk.device.DeviceClient({
                 "identity": {
-                    "orgId": "myOrg", "typeId": None, "deviceId": "myDevice"
+                    "orgId": "myOrg", "typeId": None, "deviceId": "myId"
                 },
                 "auth": { "token" : "myToken" }
             })
@@ -54,7 +53,7 @@ class TestDeviceCfg(testUtils.AbstractTest):
         with pytest.raises(wiotp.sdk.ConfigurationException) as e:
             wiotp.sdk.device.DeviceClient({
                 "identity": {
-                    "orgId": "myOrg", "typeId": "myType", "deviceId": "myDevice"
+                    "orgId": "myOrg", "typeId": "myType", "deviceId": "myId"
                 },
                 "auth": { "token" : None }
             })
@@ -67,36 +66,3 @@ class TestDeviceCfg(testUtils.AbstractTest):
         with pytest.raises(wiotp.sdk.ConfigurationException) as e:
             wiotp.sdk.device.parseConfigFile(deviceFile)
         assert e.value.reason == "Error reading device configuration file 'InvalidFile.out' ([Errno 2] No such file or directory: 'InvalidFile.out')"
-
-    def testMissingOrgIDEnvVar(self):
-        with pytest.raises(wiotp.sdk.ConfigurationException) as e:
-           os.environ['WIOTP_IDENTITY_ORGID'] = "myOrg"
-           os.environ['WIOTP_IDENTITY_TYPEID'] = "myType"
-           os.environ['WIOTP_IDENTITY_DEVICEID'] = "myDevice"
-           os.environ['WIOTP_AUTH_TOKEN'] = "myToken"
-
-           del os.environ['WIOTP_IDENTITY_ORGID']
-           wiotp.sdk.device.parseEnvVars()
-        assert e.value.reason == "Missing WIOTP_IDENTITY_ORGID environment variable"
-    
-    def testMissingTypeIDEnvVar(self):
-        with pytest.raises(wiotp.sdk.ConfigurationException) as e:
-           os.environ['WIOTP_IDENTITY_ORGID'] = "myOrg"
-           os.environ['WIOTP_IDENTITY_TYPEID'] = "myType"
-           os.environ['WIOTP_IDENTITY_DEVICEID'] = "myDevice"
-           os.environ['WIOTP_AUTH_TOKEN'] = "myToken"
-
-           del os.environ['WIOTP_IDENTITY_TYPEID']
-           wiotp.sdk.device.parseEnvVars()
-        assert e.value.reason == "Missing WIOTP_IDENTITY_TYPEID environment variable"
-
-    def testMissingDeviceIDEnvVar(self):
-        with pytest.raises(wiotp.sdk.ConfigurationException) as e:
-           os.environ['WIOTP_IDENTITY_ORGID'] = "myOrg"
-           os.environ['WIOTP_IDENTITY_TYPEID'] = "myType"
-           os.environ['WIOTP_IDENTITY_DEVICEID'] = "myDevice"
-           os.environ['WIOTP_AUTH_TOKEN'] = "myToken"
-
-           del os.environ['WIOTP_IDENTITY_DEVICEID']
-           wiotp.sdk.device.parseEnvVars()
-        assert e.value.reason == "Missing WIOTP_IDENTITY_DEVICEID environment variable"


### PR DESCRIPTION
+ Added 3 tests to check the 3 base environmental varibles

+ Changed the occurances of "myID" to "myDevice" to make keep the file consistent

+ Removed the need for the Cloudant variables when running a test