### PR TITLE
Exposing total_rows - #178 …

### DIFF
--- a/src/wiotp/sdk/api/registry/devices.py
+++ b/src/wiotp/sdk/api/registry/devices.py
@@ -56,7 +56,7 @@ class DeviceUid(defaultdict):
 
 
 class DeviceCreateRequest(defaultdict):
-    def __init__(self, typeId, deviceId, authToken=None, deviceInfo=None, location=None, metadata=None, total_rows=0):
+    def __init__(self, typeId, deviceId, authToken=None, deviceInfo=None, location=None, metadata=None):
         dict.__init__(
             self,
             typeId=typeId,
@@ -65,7 +65,6 @@ class DeviceCreateRequest(defaultdict):
             deviceInfo=deviceInfo,
             location=location,
             metadata=metadata,
-            total_rows=total_rows,
         )
 
     @property
@@ -91,10 +90,6 @@ class DeviceCreateRequest(defaultdict):
     @property
     def metadata(self):
         return self["metadata"]
-
-    @property
-    def total_rows(self):
-        return self["total_rows"]
 
 
 class DeviceLocation(defaultdict):
@@ -259,10 +254,6 @@ class Device(defaultdict):
             return self["metadata"]
         else:
             return None
-
-    @property
-    def total_rows(self):
-            return self["total_rows"]
 
     @property
     def deviceInfo(self):

--- a/src/wiotp/sdk/api/registry/devices.py
+++ b/src/wiotp/sdk/api/registry/devices.py
@@ -56,7 +56,7 @@ class DeviceUid(defaultdict):
 
 
 class DeviceCreateRequest(defaultdict):
-    def __init__(self, typeId, deviceId, authToken=None, deviceInfo=None, location=None, metadata=None, total_rows=0):
+    def __init__(self, typeId, deviceId, authToken=None, deviceInfo=None, location=None, metadata=None):
         dict.__init__(
             self,
             typeId=typeId,
@@ -65,7 +65,6 @@ class DeviceCreateRequest(defaultdict):
             deviceInfo=deviceInfo,
             location=location,
             metadata=metadata,
-            total_rows=total_rows,
         )
 
     @property
@@ -91,10 +90,6 @@ class DeviceCreateRequest(defaultdict):
     @property
     def metadata(self):
         return self["metadata"]
-
-    @property
-    def total_rows(self):
-        return self["total_rows"]
 
 
 class DeviceLocation(defaultdict):
@@ -262,7 +257,7 @@ class Device(defaultdict):
 
     @property
     def total_rows(self):
-            return self["total_rows"]
+        return self["total_rows"]
 
     @property
     def deviceInfo(self):

--- a/src/wiotp/sdk/api/registry/devices.py
+++ b/src/wiotp/sdk/api/registry/devices.py
@@ -56,7 +56,7 @@ class DeviceUid(defaultdict):
 
 
 class DeviceCreateRequest(defaultdict):
-    def __init__(self, typeId, deviceId, authToken=None, deviceInfo=None, location=None, metadata=None):
+    def __init__(self, typeId, deviceId, authToken=None, deviceInfo=None, location=None, metadata=None, total_rows=0):
         dict.__init__(
             self,
             typeId=typeId,
@@ -65,6 +65,7 @@ class DeviceCreateRequest(defaultdict):
             deviceInfo=deviceInfo,
             location=location,
             metadata=metadata,
+            total_rows=total_rows,
         )
 
     @property
@@ -90,6 +91,10 @@ class DeviceCreateRequest(defaultdict):
     @property
     def metadata(self):
         return self["metadata"]
+
+    @property
+    def total_rows(self):
+        return self["total_rows"]
 
 
 class DeviceLocation(defaultdict):
@@ -254,6 +259,10 @@ class Device(defaultdict):
             return self["metadata"]
         else:
             return None
+
+    @property
+    def total_rows(self):
+            return self["total_rows"]
 
     @property
     def deviceInfo(self):

--- a/src/wiotp/sdk/api/registry/types.py
+++ b/src/wiotp/sdk/api/registry/types.py
@@ -53,9 +53,13 @@ class DeviceType(defaultdict):
             return None
 
     @property
+    def total_rows(self):
+            return self["total_rows"]
+
+    @property
     def deviceInfo(self):
         # Unpack the deviceInfo dictionary into keyword arguments so that we
-        # can return a DeviceIngo object instead of a plain dictionary
+        # can return a DeviceInfo object instead of a plain dictionary
         if "deviceInfo" in self:
             return DeviceInfo(**self["deviceInfo"])
         else:

--- a/src/wiotp/sdk/api/registry/types.py
+++ b/src/wiotp/sdk/api/registry/types.py
@@ -54,7 +54,7 @@ class DeviceType(defaultdict):
 
     @property
     def total_rows(self):
-            return self["total_rows"]
+        return self["total_rows"]
 
     @property
     def deviceInfo(self):

--- a/src/wiotp/sdk/api/registry/types.py
+++ b/src/wiotp/sdk/api/registry/types.py
@@ -53,13 +53,9 @@ class DeviceType(defaultdict):
             return None
 
     @property
-    def total_rows(self):
-            return self["total_rows"]
-
-    @property
     def deviceInfo(self):
         # Unpack the deviceInfo dictionary into keyword arguments so that we
-        # can return a DeviceInfo object instead of a plain dictionary
+        # can return a DeviceIngo object instead of a plain dictionary
         if "deviceInfo" in self:
             return DeviceInfo(**self["deviceInfo"])
         else:

--- a/src/wiotp/sdk/api/state/devices.py
+++ b/src/wiotp/sdk/api/state/devices.py
@@ -40,10 +40,6 @@ class Device(RestApiItemBase):
         return self["metadata"]
 
     @property
-    def total_rows(self):
-        return self["total_rows"]
-
-    @property
     def registration(self):
         return self["registration"]
 

--- a/src/wiotp/sdk/api/state/devices.py
+++ b/src/wiotp/sdk/api/state/devices.py
@@ -40,6 +40,10 @@ class Device(RestApiItemBase):
         return self["metadata"]
 
     @property
+    def total_rows(self):
+        return self["total_rows"]
+
+    @property
     def registration(self):
         return self["registration"]
 


### PR DESCRIPTION
#178 - exposing the total_rows metadata so "appClient.registry.devicetypes["deviceType"].total_rows" can be used as an alternative to len(devices)