### PR TITLE
Upgrade to Python 3.8 on Alpine 3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
-      dist: xenial    # required for Python >= 3.7
+    - python: "3.8"
       env: 
        - BUILD_DOCKER_IMAGES=true
 
@@ -27,7 +27,7 @@ script:
 
 
 after_success:
-  # Only upload coverage report from pythonn 3.7 test run if BUILD_DOCKER_IMAGES is not null and not empty
+  # Only upload coverage report from pythonn 3.8 test run if BUILD_DOCKER_IMAGES is not null and not empty
   - |
     if [ -n "${BUILD_DOCKER_IMAGES}" ]; then
       coveralls

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Python module for interacting with the [IBM Watson IoT Platform](https://internetofthings.ibmcloud.com).
 
--  [Python 3.7](https://www.python.org/downloads/release/python-373/)  (recommended)
+-  [Python 3.8](https://www.python.org/downloads/release/python-373/)  (recommended)
 -  [Python 2.7](https://www.python.org/downloads/release/python-2716/)
 
 Note: Support for MQTT with TLS requires at least Python v2.7.9 and openssl v1.0.1
@@ -58,7 +58,7 @@ https://ibm-watson-iot.github.io/iot-python/
 - **Gateway Connectivity**: Connect your gateway(s) to Watson IoT Platform with ease using this library
 - **Application connectivity**: Connect your application(s) to Watson IoT Platform with ease using this library
 - **Watson IoT API**: Support for the interacting with the Watson IoT Platform through REST APIs
-- **SSL/TLS**: By default, this library connects your devices, gateways and applications securely to Watson IoT Platform registered service. Ports `8883` (default) and `443` support secure connections using TLS with the MQTT and HTTP protocol. Support for MQTT with TLS requires at least Python v2.7.9 or v3.4, and openssl v1.0.1
+- **SSL/TLS**: By default, this library connects your devices, gateways and applications securely to Watson IoT Platform registered service. Ports `8883` (default) and `443` support secure connections using TLS with the MQTT and HTTP protocol. Support for MQTT with TLS requires at least Python v2.7.9 or v3.5, and openssl v1.0.1
 - **Device Management for Device**: Connects your device(s) as managed device(s) to Watson IoT Platform.
 - **Device Management for Gateway**: Connects your gateway(s) as managed device(s) to Watson IoT Platform.
 - **Device Management Extensions**: Provides support for custom device management actions.
@@ -69,4 +69,3 @@ https://ibm-watson-iot.github.io/iot-python/
 
 ## Unsupported Features
 - **Client side Certificate based authentication**: [Client side Certificate based authentication](https://console.ng.bluemix.net/docs/services/IoT/reference/security/RM_security.html)n
-

--- a/samples/psutil/Dockerfile
+++ b/samples/psutil/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine3.9
+FROM python:3.8-alpine3.11
 
 # Add the required dependencies to install psutil that are missing from alpine
 # See: https://github.com/giampaolo/psutil/issues/872#issuecomment-272248943

--- a/setup.py
+++ b/setup.py
@@ -79,10 +79,10 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Communications',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 #         python setup.py install
 
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py27, py35, py36, py37, py38
 
 [testenv]
 deps =
@@ -19,10 +19,10 @@ deps =
     pytest
     pytest-cov
     coverage
-    py37: black
+    py38: black
 commands =
-    py37: pip install black
-    py37: black -l 120 src samples test
+    py38: pip install black
+    py38: black -l 120 src samples test
     flake8 --count --select=E9,F63,F72,F82 --show-source --statistics src samples test
     pytest --cov=wiotp.sdk {posargs}
 passenv =


### PR DESCRIPTION
Travis CI tests need to be moved from travis-ci.org to travis-ci.com
* https://travis-ci.org/github/ibm-watson-iot/iot-python