### PR TITLE
[PATCH] support for paho.mqtt.python 2.0.0

### DIFF
--- a/src/wiotp/sdk/client.py
+++ b/src/wiotp/sdk/client.py
@@ -131,8 +131,8 @@ class AbstractClient(object):
 
         # paho 2.0.0 has a breaking change for callbacks to support both 2.0.0 and 1.x we need
         # to create a client in version1 mode if using 2.0.0
-        if paho.__version__ >= "2.0.0":
-            self.client = paho.Client(paho.enums.CallbackAPIVersion.API_VERSION1, self.clientId, transport=transport, clean_session=(not cleanStart))
+        if pahoVersion >= "2.0.0":
+            self.client = paho.Client(paho.CallbackAPIVersion.VERSION1, self.clientId, transport=transport, clean_session=(not cleanStart))
         else:
             self.client = paho.Client(self.clientId, transport=transport, clean_session=(not cleanStart))
 

--- a/src/wiotp/sdk/client.py
+++ b/src/wiotp/sdk/client.py
@@ -128,7 +128,13 @@ class AbstractClient(object):
             pahoVersion,
             wiotpVersion,
         )
-        self.client = paho.Client(self.clientId, transport=transport, clean_session=(not cleanStart))
+
+        # paho 2.0.0 has a breaking change for callbacks to support both 2.0.0 and 1.x we need
+        # to create a client in version1 mode if using 2.0.0
+        if paho.__version__ >= "2.0.0":
+            self.client = paho.Client(paho.enums.CallbackAPIVersion.API_VERSION1, self.clientId, transport=transport, clean_session=(not cleanStart))
+        else:
+            self.client = paho.Client(self.clientId, transport=transport, clean_session=(not cleanStart))
 
         # Normal usage puts the client in an auto-detect mode, where it will try to use
         # TLS, and fall back to unencrypted mode ONLY if TLS 1.2 is unavailable.


### PR DESCRIPTION
Changes required to support version 2.0.0 of paho.mqtt.python without breaking support for 1.x

Version 2.0.0 introduces a new callback version, to allow for backwards compatability we need to initialize the client as using the older callback version this avoids having to rewrite all the callbacks.