### PR TITLE
[patch] add caFile: '_os_' as a way to use OS/python truststore

### DIFF
--- a/docs/application/config.md
+++ b/docs/application/config.md
@@ -17,7 +17,7 @@ Application configuration can be broken down into required and optional configur
 - `options.mqtt.cleanStart` A boolean value indicating whether to discard any previous state when reconnecting to the service.  Defaults to `False`.
 - `options.mqtt.sessionExpiry` When cleanStart is disabled, defines the maximum age of the previous session (in seconds).  Defaults to `False`.
 - `options.mqtt.keepAlive` Control the frequency of MQTT keep alive packets (in seconds).  Details to `60`.
-- `options.mqtt.caFile` A String value indicating the path to a CA file (in pem format) to use in verifying the server certificate.  Defaults to `messaging.pem` inside this module.
+- `options.mqtt.caFile` A String value indicating the path to a CA file (in pem format) to use in verifying the server certificate.  Defaults to `messaging.pem` inside this module. Use the special string `"_os_"` to use default python/OS truststore.
 
 
 The config parameter when constructing an instance of `wiotp.sdk.application.ApplicationClient` expects to be passed a dictionary containing this configuration:

--- a/docs/device/config.md
+++ b/docs/device/config.md
@@ -16,7 +16,7 @@ Device configuration can be broken down into required and optional configuration
 - `options.mqtt.cleanStart` A boolean value indicating whether to discard any previous state when reconnecting to the service.  Defaults to `False`.
 - `options.mqtt.sessionExpiry` When cleanStart is disabled, defines the maximum age of the previous session (in seconds).  Defaults to `False`.
 - `options.mqtt.keepAlive` Control the frequency of MQTT keep alive packets (in seconds).  Details to `60`.
-- `options.mqtt.caFile` A String value indicating the path to a CA file (in pem format) to use in verifying the server certificate.  Defaults to `messaging.pem` inside this module.
+- `options.mqtt.caFile` A String value indicating the path to a CA file (in pem format) to use in verifying the server certificate.  Defaults to `messaging.pem` inside this module. Use the special string `"_os_"` to use default python/OS truststore.
 
 
 The config parameter when constructing an instance of `wiotp.sdk.device.DeviceClient` expects to be passed a dictionary containing this configuration:

--- a/docs/gateway/config.md
+++ b/docs/gateway/config.md
@@ -16,7 +16,7 @@ Gateway configuration can be broken down into required and optional configuratio
 - `options.mqtt.cleanStart` A boolean value indicating whether to discard any previous state when reconnecting to the service.  Defaults to `False`.
 - `options.mqtt.sessionExpiry` When cleanStart is disabled, defines the maximum age of the previous session (in seconds).  Defaults to `False`.
 - `options.mqtt.keepAlive` Control the frequency of MQTT keep alive packets (in seconds).  Details to `60`.
-- `options.mqtt.caFile` A String value indicating the path to a CA file (in pem format) to use in verifying the server certificate.  Defaults to `messaging.pem` inside this module.
+- `options.mqtt.caFile` A String value indicating the path to a CA file (in pem format) to use in verifying the server certificate.  Defaults to `messaging.pem` inside this module. Use the special string `"_os_"` to use default python/OS truststore.
 
 
 The config parameter when constructing an instance of `wiotp.sdk.gateway.GatewayClient` expects to be passed a dictionary containing this configuration:

--- a/src/wiotp/sdk/client.py
+++ b/src/wiotp/sdk/client.py
@@ -176,6 +176,9 @@ class AbstractClient(object):
                 # Path to default CA certificate if none provided
                 if caFile is None:
                     caFile = os.path.dirname(os.path.abspath(__file__)) + "/messaging.pem"
+                elif caFile == "_os_":
+                    self.logger.debug("Using OS trust store for certification verification")
+                    caFile=None
 
                 self.client.tls_set(
                     ca_certs=caFile,


### PR DESCRIPTION
At the moment the WIoTP SDK uses a truststore file containing the certificate it expecting the server certificate to be signed by.

Even by default, it uses a messaging.pem truststore.

This change adds a special string: 
```
     caFile: '_os_'
```
If this is set, it doesn't look for an extra trust store but uses the normal truststore that python usually uses for verifying certificates.